### PR TITLE
NFC: refactor configuration role checks

### DIFF
--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -54,52 +54,54 @@ func (g *Guild) Init(c *ConfigGuild) {
 		g.Encounters.Encounters = append(g.Encounters.Encounters, encounter)
 	}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.RelevantParsing == false {
-		g.RelevantParsingEnabled = false
-	} else {
-		g.RelevantParsingEnabled = true
-	}
+	if c.ConfigRoles != nil {
+		if c.ConfigRoles.RelevantParsing == false {
+			g.RelevantParsingEnabled = false
+		} else {
+			g.RelevantParsingEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.RelevantFlexing == false {
-		g.RelevantFlexingEnabled = false
-	} else {
-		g.RelevantFlexingEnabled = true
-	}
+		if c.ConfigRoles.RelevantFlexing == false {
+			g.RelevantFlexingEnabled = false
+		} else {
+			g.RelevantFlexingEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.RelevantRepetition == false {
-		g.RelevantRepetitionEnabled = false
-	} else {
-		g.RelevantRepetitionEnabled = true
-	}
+		if c.ConfigRoles.RelevantRepetition == false {
+			g.RelevantRepetitionEnabled = false
+		} else {
+			g.RelevantRepetitionEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.Legend == false {
-		g.LegendEnabled = false
-	} else {
-		g.LegendEnabled = true
-	}
+		if c.ConfigRoles.Legend == false {
+			g.LegendEnabled = false
+		} else {
+			g.LegendEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.UltimateFlexing == false {
-		g.UltimateFlexingEnabled = false
-	} else {
-		g.UltimateFlexingEnabled = true
-	}
+		if c.ConfigRoles.UltimateFlexing == false {
+			g.UltimateFlexingEnabled = false
+		} else {
+			g.UltimateFlexingEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.UltimateRepetition == false {
-		g.UltimateRepetitionEnabled = false
-	} else {
-		g.UltimateRepetitionEnabled = true
-	}
+		if c.ConfigRoles.UltimateRepetition == false {
+			g.UltimateRepetitionEnabled = false
+		} else {
+			g.UltimateRepetitionEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.Datacenter == false {
-		g.DatacenterEnabled = false
-	} else {
-		g.DatacenterEnabled = true
-	}
+		if c.ConfigRoles.Datacenter == false {
+			g.DatacenterEnabled = false
+		} else {
+			g.DatacenterEnabled = true
+		}
 
-	if c.ConfigRoles != nil && c.ConfigRoles.SkipRemoval == true {
-		g.SkipRemoval = true
-	} else {
-		g.SkipRemoval = false
+		if c.ConfigRoles.SkipRemoval == true {
+			g.SkipRemoval = true
+		} else {
+			g.SkipRemoval = false
+		}
 	}
 
 	g.EncounterRoles = g.Encounters.Roles()


### PR DESCRIPTION
The code was refactored to simplify the checks for each configuration role. This improves readability and reduces redundancy in the code.