### PR TITLE
Add achievement roles based on cleared achievements

### DIFF
--- a/internal/clearingway/clears-handler.go
+++ b/internal/clearingway/clears-handler.go
@@ -272,6 +272,25 @@ func (c *Clearingway) UpdateClearsForCharacterInGuild(
 		}
 	}
 
+	// Add achievement roles
+	fmt.Printf("Scraping completed achievements...\n")
+	clearedAchievements, err := getAchievements(char)
+	if err != nil {
+		fmt.Printf("Please check to make sure your achievements page is not private.")
+	} else {
+		for _, role := range guild.AchievementRoles.Roles {
+			for _, clearedAchievement := range clearedAchievements {
+				if clearedAchievement == role.Description {
+					message := fmt.Sprintf("Cleared achievement %s", clearedAchievement)
+					text = append(text, fmt.Sprintf("__Adding role: **%s**__\n-> %s\n", role.Name, message))
+					rolesToApply = append(rolesToApply, &pendingRole{role: role, message: message})
+				}
+			}
+		}
+	}
+	fmt.Printf("Scraping completed.\n")
+
+
 	for _, pendingRole := range rolesToApply {
 		role := pendingRole.role
 		if role.Skip != true {


### PR DESCRIPTION
This commit scrapes the completed achievements and adds corresponding roles to the user. It fetches the cleared achievements and checks if they match any of the roles defined in the guild's AchievementRoles. If a match is found, the role is added to the user and a message is printed indicating the achievement that was cleared.

Chained PR from #9 
Issue #2 