### PR TITLE
Add /reclears command

### DIFF
--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -24,6 +24,7 @@ type ConfigRoles struct {
 	UltimateRepetition bool `yaml:"ultimateRepetition"`
 	Datacenter         bool `yaml:"datacenter"`
 	SkipRemoval        bool `yaml:"skipRemoval"`
+	Reclear            bool `yaml:"reclear"`
 }
 
 type ConfigEncounter struct {

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -26,6 +26,7 @@ type Guild struct {
 	UltimateFlexingEnabled    bool
 	UltimateRepetitionEnabled bool
 	DatacenterEnabled         bool
+	ReclearsEnabled	          bool
 	SkipRemoval               bool
 
 	EncounterRoles          *Roles
@@ -104,6 +105,12 @@ func (g *Guild) Init(c *ConfigGuild) {
 			g.DatacenterEnabled = false
 		} else {
 			g.DatacenterEnabled = true
+		}
+
+		if c.ConfigRoles.Reclear {
+			g.ReclearsEnabled = true
+		} else {
+			g.ReclearsEnabled = false
 		}
 
 		if c.ConfigRoles.SkipRemoval {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -81,6 +81,14 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			}
 			time.Sleep(1 * time.Second)
 		}
+		
+		if guild.ReclearsEnabled {
+			fmt.Printf("Adding reclears command...\n")
+			_, err = s.ApplicationCommandCreate(event.User.ID, discordGuild.ID, ReclearCommand)
+			if err != nil {
+				fmt.Printf("Could not add reclears command: %v\n", err)
+			}	
+		}
 
 		// fmt.Printf("Removing commands...\n")
 		// cmd, err := s.ApplicationCommandCreate(event.User.ID, guild.ID, verifyCommand)
@@ -174,6 +182,47 @@ var ProgCommand = &discordgo.ApplicationCommand{
 	},
 }
 
+var ReclearCommand = &discordgo.ApplicationCommand{
+	Name:	"reclears",
+	Description: "Assign or remove reclear roles",
+	Options: []*discordgo.ApplicationCommandOption{
+		{
+			Type: discordgo.ApplicationCommandOptionString,
+			Name: "ultimate",
+			Description: "The ultimate you want to reclear",
+			Required: true,
+			Choices: []*discordgo.ApplicationCommandOptionChoice{
+				{
+					Name: "UCoB",
+					Value: "The Unending Coil of Bahamut (Ultimate)",
+				},
+				{
+					Name: "UwU",
+					Value: "The Weapon's Refrain (Ultimate)",
+				},
+				{
+					Name: "TEA",
+					Value: "The Epic of Alexander (Ultimate)",
+				},
+				{
+					Name: "DSR",
+					Value: "Dragonsong's Reprise (Ultimate)",
+				},
+				{
+					Name: "TOP",
+					Value: "The Omega Protocol (Ultimate)",
+				},
+				/*
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
+				*/
+			},
+		},
+	},
+}
+
 func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	switch i.Type {
 	case discordgo.InteractionApplicationCommand:
@@ -190,6 +239,8 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			c.Prog(s, i)
 		case "removeall":
 			c.RemoveAll(s, i)
+		case "reclears":
+			c.RequestReclear(s, i)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)
@@ -463,6 +514,79 @@ func (c *Clearingway) RemoveAll(s *discordgo.Session, i *discordgo.InteractionCr
 	err = discord.ContinueInteraction(s, i.Interaction, "_ _\n__Clearingway-related roles:__\n⮕ Removed!\n")
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)
+	}
+}
+
+func (c *Clearingway) RequestReclear(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	g, ok := c.Guilds.Guilds[i.GuildID]
+	if !ok {
+		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
+		return
+	}
+
+	// Ignore messages not on the correct channel
+	if i.ChannelID != g.ChannelId {
+		fmt.Printf("Ignoring message not in channel %s.\n", g.ChannelId)
+	}
+
+	err := discord.StartInteraction(s, i.Interaction, "Checking for respective clear role...")
+	if err != nil {
+		fmt.Printf("Error sending Discord message: %v\n", err)
+		return
+	}
+
+	ultimate := i.ApplicationCommandData().Options[0].StringValue()
+	encounter := g.Encounters.ForName(ultimate)
+	reclearRole := encounter.Roles[ReclearRole]
+	clearedRole := encounter.Roles[ClearedRole]
+
+	var rolePresent = false
+	var clearPresent = false
+	for _, r := range i.Member.Roles {
+		if r == reclearRole.DiscordRole.ID {
+			rolePresent = true
+			continue
+		}
+		if r == clearedRole.DiscordRole.ID {
+			clearPresent = true
+			continue
+		}
+	}
+
+	// Remove role no matter what
+	// Add role only if cleared role is present
+	if rolePresent {
+		fmt.Printf("Removing role: %+v\n", reclearRole.Name)
+		err = reclearRole.RemoveFromCharacter(g.Id, i.Member.User.ID, c.Discord.Session)
+		if err != nil {
+			fmt.Printf("Error removing role: %+v\n", err)
+			return
+		}
+		tempstr := fmt.Sprintf("Successfully removed role: <@&%v>", reclearRole.DiscordRole.ID)
+		err = discord.ContinueInteraction(s, i.Interaction, tempstr)
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+		}
+	} else {
+		if clearPresent {
+			fmt.Printf("Adding role: %+v\n", reclearRole.Name)
+			err = reclearRole.AddToCharacter(g.Id, i.Member.User.ID, c.Discord.Session)
+			if err != nil {
+				fmt.Printf("Error adding role: %+v\n", err)
+				return
+			}
+			tempstr := fmt.Sprintf("Successfully added role: <@&%v>", reclearRole.DiscordRole.ID)
+			err = discord.ContinueInteraction(s, i.Interaction, tempstr)
+			if err != nil {
+				fmt.Printf("Error sending Discord message: %v\n", err)
+			}
+		} else {
+			tempstr := fmt.Sprintf("You do not have the required role: <@&%v>", clearedRole.DiscordRole.ID)
+			err = discord.ContinueInteraction(s, i.Interaction, tempstr)
+			if err != nil {
+				fmt.Printf("Error sending Discord message: %v\n", err)
+			}
+		}
 	}
 }
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -241,7 +241,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case "removeall":
 			c.RemoveAll(s, i)
 		case "reclears":
-			c.RequestReclear(s, i)
+			c.ToggleReclear(s, i)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)
@@ -518,7 +518,7 @@ func (c *Clearingway) RemoveAll(s *discordgo.Session, i *discordgo.InteractionCr
 	}
 }
 
-func (c *Clearingway) RequestReclear(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (c *Clearingway) ToggleReclear(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	g, ok := c.Guilds.Guilds[i.GuildID]
 	if !ok {
 		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -197,7 +197,7 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 					Value: "The Unending Coil of Bahamut (Ultimate)",
 				},
 				{
-					Name: "UwU",
+					Name: "UWU",
 					Value: "The Weapon's Refrain (Ultimate)",
 				},
 				{

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -528,6 +528,11 @@ func (c *Clearingway) RequestReclear(s *discordgo.Session, i *discordgo.Interact
 	// Ignore messages not on the correct channel
 	if i.ChannelID != g.ChannelId {
 		fmt.Printf("Ignoring message not in channel %s.\n", g.ChannelId)
+		
+		err := discord.StartInteraction(s, i.Interaction, "Command was not used in the correct channel.")
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+		}
 		return
 	}
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -212,6 +212,7 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 					Name: "TOP",
 					Value: "The Omega Protocol (Ultimate)",
 				},
+				// TODO: implement when FRU goes live
 				/*
 				{
 					Name: "FRU",
@@ -527,6 +528,7 @@ func (c *Clearingway) RequestReclear(s *discordgo.Session, i *discordgo.Interact
 	// Ignore messages not on the correct channel
 	if i.ChannelID != g.ChannelId {
 		fmt.Printf("Ignoring message not in channel %s.\n", g.ChannelId)
+		return
 	}
 
 	err := discord.StartInteraction(s, i.Interaction, "Checking for respective clear role...")


### PR DESCRIPTION
Requested by @clairefleuret
Adds a command to give the invoker the respective reclear role as configured in `config.yaml`.

## config.yaml
Based on what's already in `encounters.go`.
To enable the command in a guild: `reclear` must be set to `true` in the guild's config.
Here's a sample `config.yaml` which should work for the examples below.
```yaml
guilds:
- name: NAUR
  roles:
    reclear: true
  guildId: 1234567890
  channelId: 1234567890
  encounters:
  - ids: [1060, 1047, 1039, 1073]
    name: "The Unending Coil of Bahamut (Ultimate)"
    defaultRoles: false
    totalWeaponsAvailable: 15
    the: "Legendary"
    roles:
      - name: "UCoB Cleared"
        type: "Cleared"
        color: 0xfdfd96
      - name: "Reclear UCoB"
        type: "Reclear"
        color: 0xfdfd96
```
A separate PR will be made to modify `config.yaml` so that the commands will be set up for NAUR.
## Examples:
(Ignore the bot name I just reused the same token lol)
![image](https://github.com/user-attachments/assets/deafa95c-bdb7-4265-9f1e-bb4764b7fdda)

If prerequisite role is not present and reclear role is not present:
![image](https://github.com/user-attachments/assets/299cf86e-da0b-4acb-beba-9c5455cb2f79)

If respective reclear role is not present:
![image](https://github.com/user-attachments/assets/8926a5a8-83b7-42f2-b8d7-1ae90d409170)

If respective reclear role is present:
![image](https://github.com/user-attachments/assets/239f1e93-af33-4902-9d97-79f0fd00a62e)

