### PR TITLE
Add /namecolors command

### DIFF
--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -24,6 +24,7 @@ type ConfigRoles struct {
 	UltimateRepetition bool `yaml:"ultimateRepetition"`
 	Datacenter         bool `yaml:"datacenter"`
 	SkipRemoval        bool `yaml:"skipRemoval"`
+	NameColor          bool `yaml:"nameColor"`
 }
 
 type ConfigEncounter struct {

--- a/internal/clearingway/encounter.go
+++ b/internal/clearingway/encounter.go
@@ -143,6 +143,8 @@ func (e *Encounter) Init(c *ConfigEncounter) {
 			role.Description = "Wants to parse " + e.Name + "."
 		case ClearedRole:
 			role.Description = "Cleared " + e.Name + "."
+		case ColorRole:
+			role.Description = "Likes " + e.Name + "'s color."
 		}
 	}
 

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -26,6 +26,7 @@ type Guild struct {
 	UltimateFlexingEnabled    bool
 	UltimateRepetitionEnabled bool
 	DatacenterEnabled         bool
+	NameColorsEnabled         bool
 	SkipRemoval               bool
 
 	EncounterRoles          *Roles
@@ -104,6 +105,12 @@ func (g *Guild) Init(c *ConfigGuild) {
 			g.DatacenterEnabled = false
 		} else {
 			g.DatacenterEnabled = true
+		}
+
+		if c.ConfigRoles.NameColor {
+			g.NameColorsEnabled = true
+		} else {
+			g.NameColorsEnabled = false
 		}
 
 		if c.ConfigRoles.SkipRemoval {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -241,7 +241,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case "removeall":
 			c.RemoveAll(s, i)
 		case "namecolor":
-			c.RequestColor(s, i)
+			c.ToggleColor(s, i)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)
@@ -518,7 +518,7 @@ func (c *Clearingway) RemoveAll(s *discordgo.Session, i *discordgo.InteractionCr
 	}
 }
 
-func (c *Clearingway) RequestColor(s *discordgo.Session, i *discordgo.InteractionCreate) {
+func (c *Clearingway) ToggleColor(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	g, ok := c.Guilds.Guilds[i.GuildID]
 	if !ok {
 		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -57,6 +57,14 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			commandList = append(commandList, ProgCommand)
 		}
 
+		if guild.ReclearsEnabled {
+			commandList = append(commandList, ReclearCommand)
+		}
+
+		if guild.NameColorsEnabled {
+			commandList = append(commandList, NameColorCommand)
+		}
+
 		addedCommands, err := s.ApplicationCommandBulkOverwrite(event.User.ID, discordGuild.ID, commandList)
 		fmt.Printf("List of successfully created commands:\n")
 		for _, command := range addedCommands {
@@ -66,22 +74,6 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			fmt.Printf("Could not add some commands: %v\n", err)
 		}
 		
-		if guild.ReclearsEnabled {
-			fmt.Printf("Adding reclears command...\n")
-			_, err = s.ApplicationCommandCreate(event.User.ID, discordGuild.ID, ReclearCommand)
-			if err != nil {
-				fmt.Printf("Could not add reclears command: %v\n", err)
-			}	
-		}
-
-		if guild.NameColorsEnabled {
-			fmt.Printf("Adding namecolor command...\n")
-			_, err = s.ApplicationCommandCreate(event.User.ID, discordGuild.ID, NameColorCommand)
-			if err != nil {
-				fmt.Printf("Could not add namecolor command: %v\n", err)
-			}	
-		}
-
 		// fmt.Printf("Removing commands...\n")
 		// cmd, err := s.ApplicationCommandCreate(event.User.ID, guild.ID, verifyCommand)
 		// if err != nil {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -197,7 +197,7 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 					Value: "The Unending Coil of Bahamut (Ultimate)",
 				},
 				{
-					Name: "UwU",
+					Name: "UWU",
 					Value: "The Weapon's Refrain (Ultimate)",
 				},
 				{

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -576,22 +576,15 @@ func (c *Clearingway) RequestColor(s *discordgo.Session, i *discordgo.Interactio
 		// remove existing color role
 		tempstr := ""
 		if roleToRemove != nil {
-			fmt.Printf("Removing role: %+v\n", roleToRemove.Name)
-			err = roleToRemove.RemoveFromCharacter(g.Id, i.Member.User.ID, c.Discord.Session)
+			err = removeRoleHelper(s, i.Interaction, roleToRemove)
 			if err != nil {
-				fmt.Printf("Error removing role: %+v\n", err)
 				return
 			}
 			tempstr += fmt.Sprintf("Successfully removed role: <@&%v>", roleToRemove.DiscordRole.ID)
 		}
 		// add role if requested role is not the same as color role
 		if requestedColorRole != roleToRemove {
-			fmt.Printf("Adding role: %+v\n", requestedColorRole.Name)
-			err = requestedColorRole.AddToCharacter(g.Id, i.Member.User.ID, c.Discord.Session)
-			if err != nil {
-				fmt.Printf("Error adding role: %+v\n", err)
-				return
-			}
+			err = addRoleHelper(s, i.Interaction, requestedColorRole)
 			tempstr += fmt.Sprintf("\nSuccessfully added role: <@&%v>", requestedColorRole.DiscordRole.ID)
 		}
 		discord.ContinueInteraction(s, i.Interaction, tempstr)
@@ -599,10 +592,8 @@ func (c *Clearingway) RequestColor(s *discordgo.Session, i *discordgo.Interactio
 		// remove the requested color role if it's the same
 		// edge case where someone has clears removed and doesn't want the color 
 		if requestedColorRole == roleToRemove {
-			fmt.Printf("Removing role: %+v\n", roleToRemove.Name)
-			err = roleToRemove.RemoveFromCharacter(g.Id, i.Member.User.ID, c.Discord.Session)
+			err = removeRoleHelper(s, i.Interaction, roleToRemove)
 			if err != nil {
-				fmt.Printf("Error removing role: %+v\n", err)
 				return
 			}
 			tempstr := fmt.Sprintf("Successfully removed role: <@&%v>", roleToRemove.DiscordRole.ID)
@@ -617,6 +608,26 @@ func (c *Clearingway) RequestColor(s *discordgo.Session, i *discordgo.Interactio
 		}
 	}
 
+}
+
+func removeRoleHelper(s *discordgo.Session, i *discordgo.Interaction, roleToRemove *Role) error {
+	fmt.Printf("Removing role: %+v\n", roleToRemove.Name)
+	err := roleToRemove.RemoveFromCharacter(i.GuildID, i.Member.User.ID, s)
+	if err != nil {
+		fmt.Printf("Error removing role: %+v\n", err)
+		return err
+	}
+	return nil
+}
+
+func addRoleHelper(s *discordgo.Session, i *discordgo.Interaction, roleToAdd *Role) error {
+	fmt.Printf("Adding role: %+v\n", roleToAdd.Name)
+	err := roleToAdd.AddToCharacter(i.GuildID, i.Member.User.ID, s)
+	if err != nil {
+		fmt.Printf("Error adding role: %+v\n", err)
+		return err
+	}
+	return nil
 }
 
 func (c *Clearingway) Autocomplete(s *discordgo.Session, i *discordgo.InteractionCreate) {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -212,6 +212,7 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 					Name: "TOP",
 					Value: "The Omega Protocol (Ultimate)",
 				},
+				// TODO: implement when FRU goes live
 				/*
 				{
 					Name: "FRU",

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -527,6 +527,11 @@ func (c *Clearingway) RequestColor(s *discordgo.Session, i *discordgo.Interactio
 	// Ignore messages not on the correct channel
 	if i.ChannelID != g.ChannelId {
 		fmt.Printf("Ignoring message not in channel %s.\n", g.ChannelId)
+		err := discord.StartInteraction(s, i.Interaction, "Command was not used in the correct channel.")
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+		}
+		return
 	}
 
 	err := discord.StartInteraction(s, i.Interaction, "Checking for respective clear role...")

--- a/internal/clearingway/role.go
+++ b/internal/clearingway/role.go
@@ -28,6 +28,7 @@ var (
 	ProgRole     RoleType = "Prog"
 	LimboRole    RoleType = "Limbo"
 	CompleteRole RoleType = "Complete"
+	ColorRole    RoleType = "Name Color"
 )
 
 type Roles struct {


### PR DESCRIPTION
Requested by @clairefleuret
Adds a command to give the invoker the respective name color role as configured in `config.yaml`. Only one name color role will be applied at a given time and will remove any other name color roles already present on the user. Can be used again to toggle off the role.

## config.yaml
Based on what's already in `encounters.go`.
To enable the command in a guild: `nameColor` must be set to `true` in the guild's config.
Role `type` should be `Name Color`
Here's a sample `config.yaml` which should work for the examples below.
```yaml
guilds:
- name: NAUR
  roles:
    nameColor: true
  guildId: 1234567890
  channelId: 1234567890
  encounters:
  - ids: [1060, 1047, 1039, 1073]
    name: "The Unending Coil of Bahamut (Ultimate)"
    defaultRoles: false
    totalWeaponsAvailable: 15
    the: "Legendary"
    roles:
      - name: "UCoB Cleared"
        type: "Cleared"
        color: 0xfdfd96
      - name: "The Legend's Color"
        type: "Name Color"
        color: 0xfdfd96
```
A separate PR will be made to modify `config.yaml` so that the commands will be set up for NAUR.
## Examples:
(Ignore the bot name I just reused the same token lol)
![image](https://github.com/user-attachments/assets/880f35f3-45db-4528-833e-2838595a5940)

If prerequisite role is not present:
![image](https://github.com/user-attachments/assets/d9b958c9-038c-43cd-901d-596c2b26521d)

If prerequisite role is present and no other name color role is present:
![image](https://github.com/user-attachments/assets/2678a3f4-767a-4a44-9342-e6f0252c8ee9)

If prerequisite role is present and another name color role is present:
![image](https://github.com/user-attachments/assets/c55870b9-23ee-4ba0-b3c8-0bfc7c87df09)

If the same name color role is present (toggle role):
![image](https://github.com/user-attachments/assets/3d2cfc6b-5bf4-4844-8394-40a72710c400)