### PR TITLE
Fix kill count if user has nonstandard composition kills

### DIFF
--- a/internal/fflogs/ranking.go
+++ b/internal/fflogs/ranking.go
@@ -25,6 +25,10 @@ type Ranking struct {
 	TotalKills  int     `json:"totalKills"`
 	Metric      Metric  `json:"metric"`
 	Ranks       []*Rank `json:"ranks"`
+	
+	// odd partitions are standard comp, even partitions are nonstandard
+	// if a nonstandard response returns an odd partition,
+	// it's a copy of the standard counterpart
 	Partition   int     `json:"partition"`
 	Nonstandard bool
 }
@@ -50,10 +54,7 @@ type Report struct {
 }
 
 func (rs *Rankings) Add(id int, r *Ranking) error {
-	// odd partitions are standard comp, even partitions are nonstandard
-	// if a nonstandard response returns an odd partition,
-	// it's a copy of the standard counterpart
-	// in this case, skip any nonstandard responses that is a copy
+	// skip any nonstandard responses that is a copy of standard
 	if ((r.Partition % 2 == 0) != r.Nonstandard) {
 		return nil
 	}


### PR DESCRIPTION
There's a bug in /clears where if a user has a nonstandard kill, the kill count might be overwritten by the killcount of the nonstandard partition for the encounter id in this snippet of code below.
rankings.go
```
if r.TotalKills != 0 {
	rs.Rankings[id].TotalKills = r.TotalKills
}
```
The fix is to just add the total kills together. However, this processes through both rDPS and HPS logs separately so we're doubling the kill count if we just add all the kills. I opted to just add a single metric's kill count. I chose to use the HPS metric specifically in case there were any quirks with doing absolutely no DPS and not counting as a ranking on FFLogs' side (passive regen ticks contribute to HPS so it should always have a rank). 


The FFLogs API also has another quirk where it repeats the standard composition partition's data in the response if the nonstandard section is unavailable.
![image](https://github.com/user-attachments/assets/c1b55af5-0a15-4b81-b728-92476c2eeec7)
 This can be detected by checking the partition integer in the response, where odd is standard composition and even is nonstandard composition. I have added a check to just skip the ranking if it's just a duplicate of the counterpart.