### PR TITLE
Implement base Discord menu

### DIFF
--- a/internal/clearingway/achievement.go
+++ b/internal/clearingway/achievement.go
@@ -1,9 +1,9 @@
 package clearingway
 
 type Achievement struct {
-	Title 	 	string `yaml:"name"`
-	Type 	 	string
-	Roles 		map[RoleType]*Role
+	Title string `yaml:"name"`
+	Type  string
+	Roles map[RoleType]*Role
 }
 
 type Achievements struct {

--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -82,7 +82,6 @@ type ConfigReconfigureRoles struct {
 type ConfigMenu struct {
 	Name         string        `yaml:"name"`
 	Type         string        `yaml:"type"`
-	Blurb        string        `yaml:"blurb"`
 	Title        string        `yaml:"title"`
 	Description  string        `yaml:"description"`
 	ImageUrl     string        `yaml:"imageUrl"`

--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -13,6 +13,7 @@ type ConfigGuild struct {
 	ConfigAchievements        []*ConfigAchievement        `yaml:"achievements"`
 	ConfigRoles               *ConfigRoles                `yaml:"roles"`
 	ConfigReconfigureRoles    []*ConfigReconfigureRoles   `yaml:"reconfigureRoles"`
+	ConfigMenus               []*ConfigMenu               `yaml:"menu"`
 }
 
 type ConfigRoles struct {
@@ -76,4 +77,17 @@ type ConfigReconfigureRoles struct {
 	Skip          bool   `yaml:"skip"`
 	DontSkip      bool   `yaml:"dontSkip"`
 	Hoist         bool   `yaml:"hoist"`
+}
+
+type ConfigMenu struct {
+	Name         string        `yaml:"name"`
+	Type         string        `yaml:"type"`
+	Blurb        string        `yaml:"blurb"`
+	Title        string        `yaml:"title"`
+	Description  string        `yaml:"description"`
+	ImageUrl     string        `yaml:"imageUrl"`
+	ConfigRoles  []*ConfigRole `yaml:"roles"`
+	RoleType     []string      `yaml:"roleType"`
+	MultiSelect  bool          `yaml:"multiSelect"`
+	RequireClear bool          `yaml:"requireClear"`
 }

--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -26,6 +26,7 @@ type ConfigRoles struct {
 	SkipRemoval        bool `yaml:"skipRemoval"`
 	NameColor          bool `yaml:"nameColor"`
 	Reclear            bool `yaml:"reclear"`
+	Menu               bool `yaml:"menu"`
 }
 
 type ConfigEncounter struct {

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -293,7 +293,7 @@ func (g *Guild) InitDiscordMenu() {
 		Disabled: false,
 		CustomID: MenuVerify,
 	})
-	g.ComponentsHandlers[MenuVerify] = nil  // placeholder
+	//g.ComponentsHandlers[MenuVerify] = nil  // placeholder
 
 	// Remove Roles
 	dataMenuRemove := g.Menus.Defaults[MenuRemove]
@@ -303,7 +303,7 @@ func (g *Guild) InitDiscordMenu() {
 		Disabled: false,
 		CustomID: MenuRemove,
 	})
-	g.ComponentsHandlers[MenuRemove] = nil  // placeholder
+	//g.ComponentsHandlers[MenuRemove] = nil  // placeholder
 
 	dataMenuMain := g.Menus.Defaults[MenuMain]
 	menuMessage := &discordgo.MessageSend{

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -30,7 +30,7 @@ type Guild struct {
 	UltimateRepetitionEnabled bool
 	DatacenterEnabled         bool
 	NameColorsEnabled         bool
-	ReclearsEnabled	          bool
+	ReclearsEnabled           bool
 	MenuEnabled               bool
 	SkipRemoval               bool
 
@@ -43,7 +43,7 @@ type Guild struct {
 	UltimateRepetitionRoles *Roles
 	DatacenterRoles         *Roles
 	AchievementRoles        *Roles
-	MenuRoles               *Roles  // to ensure any additional roles added as part of menu config
+	MenuRoles               *Roles // to ensure any additional roles added as part of menu config
 }
 
 func (g *Guild) Init(c *ConfigGuild) {
@@ -55,7 +55,7 @@ func (g *Guild) Init(c *ConfigGuild) {
 	g.Characters = &ffxiv.Characters{Characters: map[string]*ffxiv.Character{}}
 	g.Menus = &Menus{Menus: map[string]*Menu{}}
 	g.DefaultMenus()
-	
+
 	g.PhysicalDatacenters = &PhysicalDatacenters{PhysicalDatacenters: map[string]*PhysicalDatacenter{}}
 	fmt.Printf("Datacenters are %+v\n", c.ConfigPhysicalDatacenters)
 	g.PhysicalDatacenters.Init(c.ConfigPhysicalDatacenters)
@@ -126,7 +126,7 @@ func (g *Guild) Init(c *ConfigGuild) {
 		} else {
 			g.NameColorsEnabled = false
 		}
-		
+
 		if c.ConfigRoles.Reclear {
 			g.ReclearsEnabled = true
 		} else {
@@ -281,8 +281,8 @@ func (g *Guild) InitDiscordMenu() {
 	dataMenuVerify := g.Menus.Menus[string(MenuVerify)]
 	customIDslice := []string{string(MenuVerify), string(CommandMenu)}
 	menuButtons = append(menuButtons, &discordgo.Button{
-		Label: dataMenuVerify.Title,
-		Style: discordgo.SuccessButton,
+		Label:    dataMenuVerify.Title,
+		Style:    discordgo.SuccessButton,
 		Disabled: false,
 		CustomID: strings.Join(customIDslice, " "),
 	})
@@ -291,8 +291,8 @@ func (g *Guild) InitDiscordMenu() {
 	dataMenuRemove := g.Menus.Menus[string(MenuRemove)]
 	customIDslice = []string{string(MenuRemove), string(CommandMenu)}
 	menuButtons = append(menuButtons, &discordgo.Button{
-		Label: dataMenuRemove.Title,
-		Style: discordgo.DangerButton,
+		Label:    dataMenuRemove.Title,
+		Style:    discordgo.DangerButton,
 		Disabled: false,
 		CustomID: strings.Join(customIDslice, " "),
 	})
@@ -301,7 +301,7 @@ func (g *Guild) InitDiscordMenu() {
 	menuMessage := &discordgo.MessageSend{
 		Embeds: []*discordgo.MessageEmbed{
 			{
-				Title: dataMenuMain.Title,
+				Title:       dataMenuMain.Title,
 				Description: dataMenuMain.Description,
 			},
 		},

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -3,7 +3,6 @@ package clearingway
 import (
 	"fmt"
 
-	"github.com/Veraticus/clearingway/internal/discord"
 	"github.com/Veraticus/clearingway/internal/ffxiv"
 	"github.com/bwmarrin/discordgo"
 )
@@ -323,18 +322,5 @@ func (g *Guild) InitDiscordMenu() {
 
 	// create a function that sends the menuMessage generated above
 	// specific to each guild
-	g.ComponentsHandlers[MenuMain] = func(s *discordgo.Session, i *discordgo.InteractionCreate) {
-		_, err := s.ChannelMessageSendComplex(i.ChannelID, menuMessage)
-		if err != nil {
-			fmt.Printf("Error sending Discord message: %v\n", err)
-			return
-		}
-
-		err = discord.StartInteraction(s, i.Interaction, "Sent menu message.")
-		if err != nil {
-			fmt.Printf("Error sending Discord message: %v\n", err)
-			return
-		}
-	}
-
+	g.ComponentsHandlers[MenuMain] = GenerateMainMenuFunc(menuMessage)
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -311,5 +311,5 @@ func (g *Guild) InitDiscordMenu() {
 			},
 		},
 	}
-	dataMenuMain.AdditionalData = &MenuStaticData{Message: menuMessage}
+	dataMenuMain.AdditionalData = &MenuMainData{Message: menuMessage}
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -43,7 +43,7 @@ type Guild struct {
 	UltimateRepetitionRoles *Roles
 	DatacenterRoles         *Roles
 	AchievementRoles        *Roles
-	MenuRoles               *Roles
+	MenuRoles               *Roles  // to ensure any additional roles added as part of menu config
 
 	ComponentsHandlers map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate)
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -311,5 +311,10 @@ func (g *Guild) InitDiscordMenu() {
 			},
 		},
 	}
+
+	if len(dataMenuMain.ImageURL) > 0 {
+		menuMessage.Embeds[0].Image = &discordgo.MessageEmbedImage{URL: dataMenuMain.ImageURL}
+	}
+
 	dataMenuMain.AdditionalData = &MenuMainData{Message: menuMessage}
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -316,5 +316,5 @@ func (g *Guild) InitDiscordMenu() {
 		menuMessage.Embeds[0].Image = &discordgo.MessageEmbedImage{URL: dataMenuMain.ImageURL}
 	}
 
-	dataMenuMain.AdditionalData = &MenuMainData{Message: menuMessage}
+	dataMenuMain.AdditionalData = &MenuAdditionalData{MessageMainMenu: menuMessage}
 }

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -211,10 +211,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},
@@ -253,10 +253,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -46,7 +46,7 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 
 		fmt.Printf("Adding commands...")
 
-		commandList := []*discordgo.ApplicationCommand {
+		commandList := []*discordgo.ApplicationCommand{
 			ClearCommand,
 			UncomfyCommand,
 			UncolorCommand,
@@ -78,7 +78,7 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 		if err != nil {
 			fmt.Printf("Could not add some commands: %v\n", err)
 		}
-		
+
 		// fmt.Printf("Removing commands...\n")
 		// cmd, err := s.ApplicationCommandCreate(event.User.ID, guild.ID, verifyCommand)
 		// if err != nil {
@@ -96,8 +96,8 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 var adminPermission int64 = discordgo.PermissionAdministrator
 
 var MenuCommand = &discordgo.ApplicationCommand{
-	Name:        "menu",
-	Description: "Send the roles menu to the current channel.",
+	Name:                     "menu",
+	Description:              "Send the roles menu to the current channel.",
 	DefaultMemberPermissions: &adminPermission,
 }
 
@@ -180,41 +180,41 @@ var ProgCommand = &discordgo.ApplicationCommand{
 }
 
 var ReclearCommand = &discordgo.ApplicationCommand{
-	Name:	"reclears",
+	Name:        "reclears",
 	Description: "Assign or remove reclear roles",
 	Options: []*discordgo.ApplicationCommandOption{
 		{
-			Type: discordgo.ApplicationCommandOptionString,
-			Name: "ultimate",
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "ultimate",
 			Description: "The ultimate you want to reclear",
-			Required: true,
+			Required:    true,
 			Choices: []*discordgo.ApplicationCommandOptionChoice{
 				{
-					Name: "UCoB",
+					Name:  "UCoB",
 					Value: "The Unending Coil of Bahamut (Ultimate)",
 				},
 				{
-					Name: "UWU",
+					Name:  "UWU",
 					Value: "The Weapon's Refrain (Ultimate)",
 				},
 				{
-					Name: "TEA",
+					Name:  "TEA",
 					Value: "The Epic of Alexander (Ultimate)",
 				},
 				{
-					Name: "DSR",
+					Name:  "DSR",
 					Value: "Dragonsong's Reprise (Ultimate)",
 				},
 				{
-					Name: "TOP",
+					Name:  "TOP",
 					Value: "The Omega Protocol (Ultimate)",
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},
@@ -222,41 +222,41 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 }
 
 var NameColorCommand = &discordgo.ApplicationCommand{
-	Name:	"namecolor",
+	Name:        "namecolor",
 	Description: "Assign or remove name color roles",
 	Options: []*discordgo.ApplicationCommandOption{
 		{
-			Type: discordgo.ApplicationCommandOptionString,
-			Name: "ultimate",
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "ultimate",
 			Description: "The ultimate that corresponds to the color you want",
-			Required: true,
+			Required:    true,
 			Choices: []*discordgo.ApplicationCommandOptionChoice{
 				{
-					Name: "UCoB",
+					Name:  "UCoB",
 					Value: "The Unending Coil of Bahamut (Ultimate)",
 				},
 				{
-					Name: "UWU",
+					Name:  "UWU",
 					Value: "The Weapon's Refrain (Ultimate)",
 				},
 				{
-					Name: "TEA",
+					Name:  "TEA",
 					Value: "The Epic of Alexander (Ultimate)",
 				},
 				{
-					Name: "DSR",
+					Name:  "DSR",
 					Value: "Dragonsong's Reprise (Ultimate)",
 				},
 				{
-					Name: "TOP",
+					Name:  "TOP",
 					Value: "The Omega Protocol (Ultimate)",
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},
@@ -320,7 +320,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
 				return
 			}
-			
+
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_encounter_menu(command[2])
@@ -669,14 +669,13 @@ func (c *Clearingway) ToggleReclear(s *discordgo.Session, i *discordgo.Interacti
 	}
 }
 
-
 func (c *Clearingway) ToggleColor(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	g, ok := c.Guilds.Guilds[i.GuildID]
 	if !ok {
 		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
 		return
 	}
-	
+
 	err := discord.StartInteraction(s, i.Interaction, "Checking for respective clear role...")
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)
@@ -695,10 +694,10 @@ func (c *Clearingway) ToggleColor(s *discordgo.Session, i *discordgo.Interaction
 			wantedEncounter = encounter
 		}
 	}
-	
+
 	requestedColorRole := wantedEncounter.Roles[ColorRole]
 	clearedRole := wantedEncounter.Roles[ClearedRole]
-	
+
 	var roleToRemove *Role
 	var cleared = false
 	for _, memberRole := range i.Member.Roles {
@@ -736,7 +735,7 @@ func (c *Clearingway) ToggleColor(s *discordgo.Session, i *discordgo.Interaction
 		discord.ContinueInteraction(s, i.Interaction, tempstr)
 	} else {
 		// remove the requested color role if it's the same
-		// edge case where someone has clears removed and doesn't want the color 
+		// edge case where someone has clears removed and doesn't want the color
 		if requestedColorRole == roleToRemove {
 			err = removeRoleHelper(s, i.Interaction, roleToRemove)
 			if err != nil {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -3,6 +3,7 @@ package clearingway
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Veraticus/clearingway/internal/discord"
@@ -283,13 +284,40 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case "reclears":
 			c.ToggleReclear(s, i)
 		case "menu":
-			c.ComponentsHandler(s, i, MenuMain)
+			c.SendStaticMenu(s, i, string(MenuMain))
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)
 	case discordgo.InteractionMessageComponent:
 		customID := i.MessageComponentData().CustomID
-		c.ComponentsHandler(s, i, customID)
+		command := strings.Split(customID, " ")
+		switch MenuType(command[0]) {
+		case MenuVerify:
+			switch CommandType(command[1]) {
+			case CommandMenu:
+				// send_modal()
+			case CommandSub1:
+				// Clears()
+			}
+		case MenuRemove:
+			switch CommandType(command[1]) {
+			case CommandMenu:
+				// send_menu()
+			case CommandSub1:
+				// Uncomfy()
+			case CommandSub2:
+				// Uncolor()
+			case CommandSub3:
+				// RemoveAll()
+			}
+		case MenuEncounter:
+			switch CommandType(command[1]) {
+			case CommandMenu:
+				// send_encounter_menu(command[2])
+			case CommandSub1:
+				// process_roles(command[2])
+			}
+		}
 	}
 }
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -291,6 +291,11 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 	case discordgo.InteractionMessageComponent:
 		customID := i.MessageComponentData().CustomID
 		command := strings.Split(customID, " ")
+		if ok := len(command) > 1; !ok {
+			fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
+			return
+		}
+
 		switch MenuType(command[0]) {
 		case MenuVerify:
 			switch CommandType(command[1]) {
@@ -311,6 +316,11 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				// RemoveAll()
 			}
 		case MenuEncounter:
+			if ok := len(command) > 2; !ok {
+				fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
+				return
+			}
+			
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_encounter_menu(command[2])

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -283,7 +283,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case "reclears":
 			c.ToggleReclear(s, i)
 		case "menu":
-			c.ComponentsHandler(s, i, createOption)
+			c.ComponentsHandler(s, i, MenuMain)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -301,18 +301,18 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_modal()
-			case CommandSub1:
+			case CommandClearsModal:
 				// Clears()
 			}
 		case MenuRemove:
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_menu()
-			case CommandSub1:
+			case CommandRemoveComfy:
 				// Uncomfy()
-			case CommandSub2:
+			case CommandRemoveColor:
 				// Uncolor()
-			case CommandSub3:
+			case CommandRemoveAll:
 				// RemoveAll()
 			}
 		case MenuEncounter:
@@ -324,7 +324,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_encounter_menu(command[2])
-			case CommandSub1:
+			case CommandEncounterProcess:
 				// process_roles(command[2])
 			}
 		}

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -284,7 +284,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case "reclears":
 			c.ToggleReclear(s, i)
 		case "menu":
-			c.SendStaticMenu(s, i, string(MenuMain))
+			c.MenuMainSend(s, i)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -65,6 +65,10 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			commandList = append(commandList, NameColorCommand)
 		}
 
+		if guild.MenuEnabled {
+			commandList = append(commandList, MenuCommand)
+		}
+
 		addedCommands, err := s.ApplicationCommandBulkOverwrite(event.User.ID, discordGuild.ID, commandList)
 		fmt.Printf("List of successfully created commands:\n")
 		for _, command := range addedCommands {
@@ -86,6 +90,14 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 	}
 	fmt.Printf("Clearingway ready!\n")
 	c.Ready = true
+}
+
+var adminPermission int64 = discordgo.PermissionAdministrator
+
+var MenuCommand = &discordgo.ApplicationCommand{
+	Name:        "menu",
+	Description: "Send the roles menu to the current channel.",
+	DefaultMemberPermissions: &adminPermission,
 }
 
 var ClearCommand = &discordgo.ApplicationCommand{
@@ -270,9 +282,14 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			c.ToggleColor(s, i)
 		case "reclears":
 			c.ToggleReclear(s, i)
+		case "menu":
+			c.ComponentsHandler(s, i, createOption)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
 		c.Autocomplete(s, i)
+	case discordgo.InteractionMessageComponent:
+		customID := i.MessageComponentData().CustomID
+		c.ComponentsHandler(s, i, customID)
 	}
 }
 

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -6,15 +6,140 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-// Strings that will be used to access guild-specific functions
+// guaranteed UI elements
 const(
-	createOption string = "menucreate"
-	verifyOption string = "menuverify"
-	reclearOption string = "menureclear"
-	progOption string = "menuprog"
-	colorOption string = "menucolor"
-	removeOption string = "menuremove"
+	MenuMain    string = "menucreate"
+	MenuVerify  string = "menuverify"
+	MenuRemove  string = "menuremove"
 )
+
+// menu types
+// currently only default/guaranteed menus, dropdown menu based on encounters
+type MenuType string
+const (
+	MenuTypeDefault   MenuType = "default"
+	MenuTypeEncounter MenuType = "encounter"
+)
+
+// struct to hold data for all different menu components
+type Menus struct {
+	Defaults map[string]*Menu
+	Menus    []*Menu
+}
+
+type Menu struct {
+	Name           string  // internal name e.g "menureclear"
+	Type           MenuType
+	Blurb          string
+	Title          string  // title to show in embed
+	Description    string  // optional description to show in embed
+	ImageURL       string  // optional image URL
+	AdditionalData MenuComponent  // additional data depending on MenuType
+}
+
+type MenuComponent interface{
+	Type() MenuType
+}
+
+type MenuRoleHelper struct {
+	Role         *Role
+	Prerequisite *Role
+}
+
+type MenuTypeEncounterData struct {
+	Roles        map[string]*MenuRoleHelper
+	ExtraRoles   []*Role
+	RoleType     []RoleType
+	MultiSelect  bool
+	RequireClear bool
+}
+
+func (MenuTypeEncounterData) Type() MenuType {
+	return MenuTypeEncounter
+}
+
+func (m *Menu) Init(c *ConfigMenu) {
+	m.Name = c.Name
+	m.Type = MenuType(c.Type)
+	m.Blurb = c.Blurb
+	m.Title = c.Title
+
+	if len(c.Description) != 0 {
+		m.Description = c.Description
+	}
+
+	if len(c.ImageUrl) != 0 {
+		m.ImageURL = c.ImageUrl
+	}
+
+	switch m.Type {
+	case MenuTypeDefault:
+	case MenuTypeEncounter:
+		m.Type = MenuTypeEncounter
+		m.AdditionalData = &MenuTypeEncounterData{}
+		data := m.AdditionalData.(*MenuTypeEncounterData)
+
+		if len(c.RoleType) != 0 {
+			for _, roleType := range c.RoleType {
+				data.RoleType = append(data.RoleType, RoleType(roleType))
+			}
+		}
+
+		if c.MultiSelect {
+			data.MultiSelect = true
+		} else {
+			data.MultiSelect = false
+		}
+
+		if c.RequireClear {
+			data.RequireClear = true
+		} else {
+			data.RequireClear = false
+		}
+
+		for _, configRole := range c.ConfigRoles {
+			role := &Role{}
+			if len(configRole.Name) != 0 {
+				role.Name = configRole.Name
+			}
+			if len(configRole.Description) != 0 {
+				role.Description = configRole.Description
+			}
+			if configRole.Color != 0 {
+				role.Color = configRole.Color
+			}
+			if configRole.Hoist {
+				role.Hoist = true
+			}
+			if configRole.Mention {
+				role.Mention = true
+			}
+			data.ExtraRoles = append(data.ExtraRoles, role)
+		}
+	}
+}
+
+func (g *Guild) DefaultMenus() {
+	g.Menus.Defaults[MenuMain] = &Menu{
+		Name: MenuMain,
+		Type: MenuTypeDefault,
+		Title: "Welcome to " + g.Name,
+		Description: "Use the buttons below to assign roles!",
+	}
+
+	g.Menus.Defaults[MenuVerify] = &Menu{
+		Name: MenuVerify,
+		Type: MenuTypeDefault,
+		Title: "Verify Character",
+	}
+
+	g.Menus.Defaults[MenuRemove] = &Menu{
+		Name: MenuRemove,
+		Type: MenuTypeDefault,
+		Title: "Remove Roles",
+		Description: "Use the buttons below to remove Clearingway related roles!",
+	}
+}
 
 // ComponentsHandler is function that executes the respective guild specific functions
 func (c *Clearingway) ComponentsHandler(s *discordgo.Session, i *discordgo.InteractionCreate, customID string){
@@ -24,4 +149,18 @@ func (c *Clearingway) ComponentsHandler(s *discordgo.Session, i *discordgo.Inter
 		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
 		return
 	}
+}
+
+// Returns with all the additional roles that were specified
+// by the yaml under the menu config
+func (ms *Menus) Roles() *Roles {
+	roles := &Roles{Roles: []*Role{}}
+
+	for _, menu := range ms.Menus {
+		if menu.Type == MenuTypeEncounter {
+			roles.Roles = append(roles.Roles, menu.AdditionalData.(*MenuTypeEncounterData).ExtraRoles...)
+		}
+	}
+
+	return roles
 }

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -161,7 +161,12 @@ func GenerateMainMenuFunc(menuMessage *discordgo.MessageSend) func(s *discordgo.
 // ComponentsHandler is function that executes the respective guild specific functions
 func (c *Clearingway) ComponentsHandler(s *discordgo.Session, i *discordgo.InteractionCreate, customID string){
 	if g, ok := c.Guilds.Guilds[i.GuildID]; ok {
-		g.ComponentsHandlers[customID](s, i)
+		if f, ok := g.ComponentsHandlers[customID]; ok {
+			f(s, i)
+		} else {
+			fmt.Printf("Invalid Custom ID received: %v\n", customID)
+			return
+		}
 	} else {
 		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
 		return

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -9,7 +9,8 @@ import (
 
 // types of UI elements
 type MenuType string
-const(
+
+const (
 	MenuMain      MenuType = "menuMain"
 	MenuVerify    MenuType = "menuVerify"
 	MenuRemove    MenuType = "menuRemove"
@@ -17,7 +18,8 @@ const(
 )
 
 type CommandType string
-const(
+
+const (
 	CommandMenu CommandType = "menu"
 	CommandSub1 CommandType = "sub1"
 	CommandSub2 CommandType = "sub2"
@@ -26,16 +28,16 @@ const(
 
 // struct to hold data for all different menu components
 type Menus struct {
-	Menus    map[string]*Menu
+	Menus map[string]*Menu
 }
 
 type Menu struct {
-	Name           string  // internal name to uniquely identify menus
-	Type           MenuType  // type of menu to differentiate AdditionalData types
-	Title          string  // title to show in embed
-	Description    string  // optional description to show in embed
-	ImageURL       string  // optional image URL
-	AdditionalData *MenuAdditionalData  // additional data depending on MenuType
+	Name           string              // internal name to uniquely identify menus
+	Type           MenuType            // type of menu to differentiate AdditionalData types
+	Title          string              // title to show in embed
+	Description    string              // optional description to show in embed
+	ImageURL       string              // optional image URL
+	AdditionalData *MenuAdditionalData // additional data depending on MenuType
 }
 
 type MenuRoleHelper struct {
@@ -44,13 +46,13 @@ type MenuRoleHelper struct {
 }
 
 type MenuAdditionalData struct {
-	MessageMainMenu *discordgo.MessageSend
+	MessageMainMenu  *discordgo.MessageSend
 	MessageEphemeral *discordgo.InteractionResponse
-	Roles        map[string]*MenuRoleHelper
-	ExtraRoles   []*Role
-	RoleType     []RoleType
-	MultiSelect  bool
-	RequireClear bool
+	Roles            map[string]*MenuRoleHelper
+	ExtraRoles       []*Role
+	RoleType         []RoleType
+	MultiSelect      bool
+	RequireClear     bool
 }
 
 func (m *Menu) Init(c *ConfigMenu) {
@@ -113,22 +115,22 @@ func (m *Menu) Init(c *ConfigMenu) {
 
 func (g *Guild) DefaultMenus() {
 	g.Menus.Menus[string(MenuMain)] = &Menu{
-		Name: string(MenuMain),
-		Type: MenuMain,
-		Title: "Welcome to " + g.Name,
+		Name:        string(MenuMain),
+		Type:        MenuMain,
+		Title:       "Welcome to " + g.Name,
 		Description: "Use the buttons below to assign roles!",
 	}
 
 	g.Menus.Menus[string(MenuVerify)] = &Menu{
-		Name: string(MenuVerify),
-		Type: MenuVerify,
+		Name:  string(MenuVerify),
+		Type:  MenuVerify,
 		Title: "Verify Character",
 	}
 
 	g.Menus.Menus[string(MenuRemove)] = &Menu{
-		Name: string(MenuRemove),
-		Type: MenuRemove,
-		Title: "Remove Roles",
+		Name:        string(MenuRemove),
+		Type:        MenuRemove,
+		Title:       "Remove Roles",
 		Description: "Use the buttons below to remove Clearingway related roles!",
 	}
 }
@@ -157,7 +159,7 @@ func (c *Clearingway) MenuMainSend(s *discordgo.Session, i *discordgo.Interactio
 	}
 }
 
-// Creates an response to an interaction with a static menu 
+// Creates an response to an interaction with a static menu
 func (c *Clearingway) MenuStaticRespond(s *discordgo.Session, i *discordgo.InteractionCreate, menuName string) {
 	g, ok := c.Guilds.Guilds[i.GuildID]
 	if !ok {
@@ -167,7 +169,7 @@ func (c *Clearingway) MenuStaticRespond(s *discordgo.Session, i *discordgo.Inter
 
 	menu := g.Menus.Menus[menuName]
 	additionalData := menu.AdditionalData
-	
+
 	err := s.InteractionRespond(i.Interaction, additionalData.MessageEphemeral)
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -20,10 +20,12 @@ const (
 type CommandType string
 
 const (
-	CommandMenu CommandType = "menu"
-	CommandSub1 CommandType = "sub1"
-	CommandSub2 CommandType = "sub2"
-	CommandSub3 CommandType = "sub3"
+	CommandMenu             CommandType = "menu"
+	CommandClearsModal      CommandType = "clearsModal"
+	CommandRemoveComfy      CommandType = "removeComfy"
+	CommandRemoveColor      CommandType = "removeColor"
+	CommandRemoveAll        CommandType = "removeAll"
+	CommandEncounterProcess CommandType = "encounterProcess"
 )
 
 // struct to hold data for all different menu components

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -1,0 +1,27 @@
+package clearingway
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// Strings that will be used to access guild-specific functions
+const(
+	createOption string = "menucreate"
+	verifyOption string = "menuverify"
+	reclearOption string = "menureclear"
+	progOption string = "menuprog"
+	colorOption string = "menucolor"
+	removeOption string = "menuremove"
+)
+
+// ComponentsHandler is function that executes the respective guild specific functions
+func (c *Clearingway) ComponentsHandler(s *discordgo.Session, i *discordgo.InteractionCreate, customID string){
+	if g, ok := c.Guilds.Guilds[i.GuildID]; ok {
+		g.ComponentsHandlers[customID](s, i)
+	} else {
+		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
+		return
+	}
+}

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -29,7 +29,7 @@ type Menus struct {
 
 type Menu struct {
 	Name           string  // internal name e.g "menuReclear"
-	Type           MenuType
+	Type           MenuType  // type of menu to differentiate AdditionalData types
 	Title          string  // title to show in embed
 	Description    string  // optional description to show in embed
 	ImageURL       string  // optional image URL

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -30,7 +30,6 @@ type Menus struct {
 type Menu struct {
 	Name           string  // internal name e.g "menuReclear"
 	Type           MenuType
-	Blurb          string
 	Title          string  // title to show in embed
 	Description    string  // optional description to show in embed
 	ImageURL       string  // optional image URL
@@ -61,7 +60,6 @@ func (MenuTypeEncounterData) Type() MenuType {
 func (m *Menu) Init(c *ConfigMenu) {
 	m.Name = c.Name
 	m.Type = MenuType(c.Type)
-	m.Blurb = c.Blurb
 	m.Title = c.Title
 
 	if len(c.Description) != 0 {

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -8,9 +8,9 @@ import (
 
 // guaranteed UI elements
 const(
-	MenuMain    string = "menucreate"
-	MenuVerify  string = "menuverify"
-	MenuRemove  string = "menuremove"
+	MenuMain    string = "menuCreate"
+	MenuVerify  string = "menuVerify"
+	MenuRemove  string = "menuRemove"
 )
 
 // menu types
@@ -28,7 +28,7 @@ type Menus struct {
 }
 
 type Menu struct {
-	Name           string  // internal name e.g "menureclear"
+	Name           string  // internal name e.g "menuReclear"
 	Type           MenuType
 	Blurb          string
 	Title          string  // title to show in embed

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -3,6 +3,7 @@ package clearingway
 import (
 	"fmt"
 
+	"github.com/Veraticus/clearingway/internal/discord"
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -136,6 +137,24 @@ func (g *Guild) DefaultMenus() {
 		Type: MenuTypeDefault,
 		Title: "Remove Roles",
 		Description: "Use the buttons below to remove Clearingway related roles!",
+	}
+}
+
+// GenerateMainMenuFunc returns a guild-specific function that responds
+// with the main menu of the guild set up according to the config file
+func GenerateMainMenuFunc(menuMessage *discordgo.MessageSend) func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	return func(s *discordgo.Session, i *discordgo.InteractionCreate) {
+		_, err := s.ChannelMessageSendComplex(i.ChannelID, menuMessage)
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+			return
+		}
+
+		err = discord.StartInteraction(s, i.Interaction, "Sent menu message.")
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+			return
+		}
 	}
 }
 

--- a/internal/fflogs/fflogs.go
+++ b/internal/fflogs/fflogs.go
@@ -1,7 +1,5 @@
 package fflogs
 
-import ()
-
 func Init(clientId, clientSecret string) *Fflogs {
 	f := &Fflogs{
 		clientId:     clientId,

--- a/internal/fflogs/ranking.go
+++ b/internal/fflogs/ranking.go
@@ -21,15 +21,15 @@ const (
 )
 
 type Ranking struct {
-	Error       string  `json:"error"`
-	TotalKills  int     `json:"totalKills"`
-	Metric      Metric  `json:"metric"`
-	Ranks       []*Rank `json:"ranks"`
-	
+	Error      string  `json:"error"`
+	TotalKills int     `json:"totalKills"`
+	Metric     Metric  `json:"metric"`
+	Ranks      []*Rank `json:"ranks"`
+
 	// odd partitions are standard comp, even partitions are nonstandard
 	// if a nonstandard response returns an odd partition,
 	// it's a copy of the standard counterpart
-	Partition   int     `json:"partition"`
+	Partition   int `json:"partition"`
 	Nonstandard bool
 }
 
@@ -55,7 +55,7 @@ type Report struct {
 
 func (rs *Rankings) Add(id int, r *Ranking) error {
 	// skip any nonstandard responses that is a copy of standard
-	if ((r.Partition % 2 == 0) != r.Nonstandard) {
+	if (r.Partition%2 == 0) != r.Nonstandard {
 		return nil
 	}
 	existingRankings, ok := rs.Rankings[id]
@@ -77,7 +77,7 @@ func (rs *Rankings) Add(id int, r *Ranking) error {
 		}
 
 		// only count a single metric's kill count so we don't double it
-		if (r.Metric == "rdps") {
+		if r.Metric == "rdps" {
 			r.TotalKills = 0
 		}
 		rs.Rankings[id] = r


### PR DESCRIPTION
This PR implements a base menu (`/menu`) that will provide a user interface for role-related commands.
Each component of the menu can be configured through the YAML file. 
Here's a snippet:
```yaml
guilds:
- name: NAUR
  roles:
    menu: true
...
  menu:
    - name: "menucreate"
      type: "default"
      title: "NAUR Role Assignment"
      description: |-
        Cool description here
```
![image](https://github.com/user-attachments/assets/e221c87a-d452-4238-9015-5bd914abedb8)

### To implement
- Clear modal: #33 
- Encounter-based role selection: #34 
- Remove roles menu: TBD