### PR TITLE
Add encounter-based role selection menus

### DIFF
--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -287,6 +287,18 @@ func (g *Guild) InitDiscordMenu() {
 		CustomID: strings.Join(customIDslice, " "),
 	})
 
+	// Add yaml configured menus
+	for _, menu := range(g.Menus.Menus) {
+		menuButtons = append(menuButtons, &discordgo.Button{
+			Label: menu.Title,
+			Style: discordgo.PrimaryButton,
+			Disabled: false,
+			CustomID: menu.Name,
+		})
+
+		g.ComponentsHandlers[menu.Name + "process"] = menu.ProcessMenuEncounter()
+	}
+
 	// Remove Roles
 	dataMenuRemove := g.Menus.Menus[string(MenuRemove)]
 	customIDslice = []string{string(MenuRemove), string(CommandMenu)}

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -288,15 +288,16 @@ func (g *Guild) InitDiscordMenu() {
 	})
 
 	// Add yaml configured menus
-	for _, menu := range(g.Menus.Menus) {
-		menuButtons = append(menuButtons, &discordgo.Button{
-			Label: menu.Title,
-			Style: discordgo.PrimaryButton,
-			Disabled: false,
-			CustomID: menu.Name,
-		})
-
-		g.ComponentsHandlers[menu.Name + "process"] = menu.ProcessMenuEncounter()
+	for _, menu := range g.Menus.Menus {
+		if menu.Type == MenuEncounter {
+			customIDslice = []string{string(MenuEncounter), string(CommandMenu), menu.Name}
+			menuButtons = append(menuButtons, &discordgo.Button{
+				Label: menu.Title,
+				Style: discordgo.PrimaryButton,
+				Disabled: false,
+				CustomID: strings.Join(customIDslice, " "),
+			})
+		}
 	}
 
 	// Remove Roles

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -45,7 +45,7 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 
 		for _, menu := range guild.Menus.Menus {
 			if menu.Type == MenuEncounter {
-				additionalData := menu.AdditionalData.(*MenuEncounterData)
+				additionalData := menu.AdditionalData
 				menu.MenuEncounterInit(guild.Encounters, additionalData.RoleType)
 			}
 		}
@@ -330,9 +330,9 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			}
 			switch CommandType(command[1]) {
 			case CommandMenu:
-				// send_encounter_menu(command[2])
+				c.MenuEncounterSend(s, i, command[2])
 			case CommandEncounterProcess:
-				// process_roles(command[2])
+				c.MenuEncounterProcess(s, i, command[2])
 			}
 		}
 	}

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -211,10 +211,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},
@@ -253,10 +253,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -219,10 +219,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},
@@ -261,10 +261,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -44,10 +44,9 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 		}
 
 		for _, menu := range guild.Menus.Menus {
-			if menu.Type == MenuTypeEncounter {
-				additionalData := menu.AdditionalData.(*MenuTypeEncounterData)
-				menuMessageFunction := menu.MenuEncounter(guild.Encounters, additionalData.RoleType)
-				guild.ComponentsHandlers[menu.Name] = menuMessageFunction
+			if menu.Type == MenuEncounter {
+				additionalData := menu.AdditionalData.(*MenuEncounterData)
+				menu.MenuEncounterInit(guild.Encounters, additionalData.RoleType)
 			}
 		}
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -320,7 +320,6 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
 				return
 			}
-
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_encounter_menu(command[2])

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -298,6 +298,11 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		c.Autocomplete(s, i)
 	case discordgo.InteractionMessageComponent:
 		customID := i.MessageComponentData().CustomID
+
+		// commands are differentiated by the customID with the format
+		// [menu type] [command type] [menu name]
+		// e.g "MenuEncounter encounterProcess menuProg"
+		// menu name is optional and only applies to encounter based menus for now
 		command := strings.Split(customID, " ")
 		if ok := len(command) > 1; !ok {
 			fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -42,6 +42,15 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 				fmt.Printf("Error ensuring role %+v: %+v\n", r, err)
 			}
 		}
+
+		for _, menu := range guild.Menus.Menus {
+			if menu.Type == MenuTypeEncounter {
+				additionalData := menu.AdditionalData.(*MenuTypeEncounterData)
+				menuMessageFunction := menu.MenuEncounter(guild.Encounters, additionalData.RoleType)
+				guild.ComponentsHandlers[menu.Name] = menuMessageFunction
+			}
+		}
+
 		time.Sleep(1 * time.Second)
 
 		fmt.Printf("Adding commands...")

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -191,6 +191,7 @@ func (m *Menu) MenuEncounterInit(es *Encounters, roleTypes []RoleType) {
 		for _, encounter := range es.Encounters {
 			role, ok := encounter.Roles[roleType]
 			if !ok {
+				fmt.Printf("Menu %v: role type %v for encounter %v not found. Skipping...\n", m.Name, string(roleType), encounter.Name)
 				continue
 			}
 
@@ -412,7 +413,7 @@ func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.In
 		length := len(roles)
 		if length == 1 {
 			responseMsg += fmt.Sprintf("Successfully %v role: <@&%v>\n", verb, roles[0])
-		} else if length > 1 {
+		} else {
 			responseMsg += fmt.Sprintf("Successfully %v roles: ", verb)
 			for _, role := range roles {
 				responseMsg += fmt.Sprintf("<@&%v> ", role)

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -429,12 +429,12 @@ func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.In
 	if len(errorRoles) != 0 {
 		responseMsg += "An error has occurred. Please contact an admin with this message.\nRole actions that failed: "
 		for _, role := range errorRoles {
-			responseMsg += fmt.Sprintf("<@&%v> ", role)
+			responseMsg += fmt.Sprintf("<@&%v>\n", role)
 		}
 	}
 
 	if len(responseMsg) == 0 {
-		responseMsg = "Nothing has been done!"
+		responseMsg = "Nothing has been done!\n"
 	}
 	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 		Content: &responseMsg,

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -2,6 +2,7 @@ package clearingway
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Veraticus/clearingway/internal/discord"
 	"github.com/bwmarrin/discordgo"
@@ -173,6 +174,267 @@ func (c *Clearingway) MenuStaticRespond(s *discordgo.Session, i *discordgo.Inter
 	additionalData := menu.AdditionalData
 
 	err := s.InteractionRespond(i.Interaction, additionalData.MessageEphemeral)
+	if err != nil {
+		fmt.Printf("Error sending Discord message: %v\n", err)
+		return
+	}
+}
+
+func (m *Menu) MenuEncounterInit(es *Encounters, roleTypes []RoleType) {
+	additionalData := m.AdditionalData
+	additionalData.Roles = make(map[string]*MenuRoleHelper)
+	minValues := 0
+	maxValues := 1
+	dropdownSlice := []discordgo.SelectMenuOption{}
+
+	// generate options based on encounters
+	for _, roleType := range roleTypes {
+		for _, encounter := range es.Encounters {
+			role, ok := encounter.Roles[roleType]
+			if !ok {
+				continue
+			}
+
+			dropdownOption := discordgo.SelectMenuOption{
+				Label:   role.Name,
+				Value:   role.DiscordRole.ID,
+				Default: false,
+			}
+
+			menuRoleHelper := &MenuRoleHelper{
+				Role: role,
+			}
+
+			if additionalData.RequireClear {
+				if prereq, ok := encounter.Roles[ClearedRole]; ok {
+					menuRoleHelper.Prerequisite = prereq
+				}
+			}
+
+			dropdownSlice = append(dropdownSlice, dropdownOption)
+			additionalData.Roles[role.DiscordRole.ID] = menuRoleHelper
+		}
+	}
+
+	// generate options based on additional roles
+	for _, role := range additionalData.ExtraRoles {
+		dropdownOption := discordgo.SelectMenuOption{
+			Label:   role.Name,
+			Value:   role.DiscordRole.ID,
+			Default: false,
+		}
+
+		menuRoleHelper := &MenuRoleHelper{
+			Role: role,
+		}
+
+		dropdownSlice = append(dropdownSlice, dropdownOption)
+		additionalData.Roles[role.DiscordRole.ID] = menuRoleHelper
+	}
+
+	// generate role list
+	descriptionRoleList := "\n### Available roles"
+	for _, role := range dropdownSlice {
+		descriptionRoleList += fmt.Sprintf("\n- %s", role.Label)
+	}
+
+	if additionalData.MultiSelect {
+		maxValues = len(dropdownSlice)
+	}
+
+	// format response message
+	customID := []string{string(MenuEncounter), string(CommandEncounterProcess), m.Name}
+	dropdownMenu := discordgo.SelectMenu{
+		MenuType:  discordgo.StringSelectMenu,
+		CustomID:  strings.Join(customID, " "),
+		Options:   dropdownSlice,
+		MinValues: &minValues,
+		MaxValues: maxValues,
+	}
+
+	additionalData.MessageEphemeral = &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Flags: discordgo.MessageFlagsEphemeral,
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       m.Title,
+					Description: m.Description + descriptionRoleList,
+				},
+			},
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						dropdownMenu,
+					},
+				},
+			},
+		},
+	}
+
+	if len(m.ImageURL) != 0 {
+		additionalData.MessageEphemeral.Data.Embeds[0].Image = &discordgo.MessageEmbedImage{
+			URL: m.ImageURL,
+		}
+	}
+}
+
+func (c *Clearingway) MenuEncounterSend(s *discordgo.Session, i *discordgo.InteractionCreate, menuName string) {
+	g, ok := c.Guilds.Guilds[i.GuildID]
+	if !ok {
+		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
+		return
+	}
+
+	userRoles := i.Member.Roles
+	userRoleMap := make(map[string]struct{})
+	for _, role := range userRoles {
+		userRoleMap[role] = struct{}{}
+	}
+
+	menu := g.Menus.Menus[menuName]
+	additionalData := menu.AdditionalData
+
+	// create a copy of the message
+	message := *additionalData.MessageEphemeral
+	dropdownOpts := message.Data.Components[0].(discordgo.ActionsRow).Components[0].(discordgo.SelectMenu).Options
+
+	// set default selections based on roles present
+	for i, _ := range dropdownOpts {
+		option := &dropdownOpts[i]
+		if _, ok := userRoleMap[option.Value]; ok {
+			option.Default = true
+		}
+	}
+	err := s.InteractionRespond(i.Interaction, additionalData.MessageEphemeral)
+
+	if err != nil {
+		fmt.Printf("Unable to respond with menu: %v", err)
+		return
+	}
+
+}
+
+func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.InteractionCreate, menuName string) {
+	err := discord.StartInteraction(s, i.Interaction, "Processing request...")
+	if err != nil {
+		fmt.Printf("Error sending Discord message: %v\n", err)
+		return
+	}
+
+	g, ok := c.Guilds.Guilds[i.GuildID]
+	if !ok {
+		fmt.Printf("Interaction received from guild %s with no configuration!\n", i.GuildID)
+		return
+	}
+
+	menu := g.Menus.Menus[menuName]
+	additionalData := menu.AdditionalData
+
+	userOptions := i.MessageComponentData().Values
+	userOptionsMap := make(map[string]struct{})
+	for _, opt := range userOptions {
+		userOptionsMap[opt] = struct{}{}
+	}
+
+	userRoles := i.Member.Roles
+	userRolesMap := make(map[string]struct{})
+	for _, roleId := range userRoles {
+		userRolesMap[roleId] = struct{}{}
+	}
+
+	// check which roles to add or remove
+	rolesToAdd := []*MenuRoleHelper{}
+	rolesToRemove := []*Role{}
+	for _, roleHelper := range additionalData.Roles {
+		role := roleHelper.Role
+
+		_, selected := userOptionsMap[role.DiscordRole.ID]
+		_, present := userRolesMap[role.DiscordRole.ID]
+
+		if selected && !present {
+			rolesToAdd = append(rolesToAdd, roleHelper)
+		} else if !selected && present {
+			rolesToRemove = append(rolesToRemove, role)
+		}
+	}
+
+	successRoles := []string{}
+	removedRoles := []string{}
+	failedRoles := []string{}
+	errorRoles := []string{}
+
+	// add/remove roles based on prereq met
+	for _, roleHelper := range rolesToAdd {
+		prereq := roleHelper.Prerequisite
+		if roleHelper.Prerequisite != nil {
+			if _, prereqMet := userRolesMap[prereq.DiscordRole.ID]; !prereqMet {
+				failedRoles = append(failedRoles, roleHelper.Prerequisite.DiscordRole.ID)
+				continue
+			}
+		}
+
+		err := roleHelper.Role.AddToCharacter(i.GuildID, i.Member.User.ID, s)
+		if err != nil {
+			fmt.Printf("Error adding role: %+v\n", err)
+			errorRoles = append(errorRoles, roleHelper.Role.DiscordRole.ID)
+			continue
+		}
+
+		successRoles = append(successRoles, roleHelper.Role.DiscordRole.ID)
+	}
+
+	for _, role := range rolesToRemove {
+		err := role.RemoveFromCharacter(i.GuildID, i.Member.User.ID, s)
+		if err != nil {
+			fmt.Printf("Error removing role: %+v\n", err)
+			errorRoles = append(errorRoles, role.DiscordRole.ID)
+			continue
+		}
+
+		removedRoles = append(removedRoles, role.DiscordRole.ID)
+	}
+
+	// form response string
+	responseMsg := ""
+
+	for i, roles := range [2][]string{successRoles, removedRoles} {
+		verb := ""
+		if i == 0 {
+			verb = "added"
+		} else {
+			verb = "removed"
+		}
+
+		length := len(roles)
+		if length == 1 {
+			responseMsg += fmt.Sprintf("Successfully %v role: <@&%v>\n", verb, roles[0])
+		} else if length > 1 {
+			responseMsg += fmt.Sprintf("Successfully %v roles: ", verb)
+			for _, role := range roles {
+				responseMsg += fmt.Sprintf("<@&%v> ", role)
+			}
+			responseMsg += "\n"
+		}
+	}
+
+	for _, failedRole := range failedRoles {
+		responseMsg += fmt.Sprintf("You do not have the required role: <@&%v>\n", failedRole)
+	}
+
+	if len(errorRoles) != 0 {
+		responseMsg += "An error has occurred. Please contact an admin with this message.\nRole actions that failed: "
+		for _, role := range errorRoles {
+			responseMsg += fmt.Sprintf("<@&%v> ", role)
+		}
+	}
+
+	if len(responseMsg) == 0 {
+		responseMsg = "Nothing has been done!"
+	}
+	_, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: &responseMsg,
+	})
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)
 		return

--- a/internal/clearingway/role.go
+++ b/internal/clearingway/role.go
@@ -29,6 +29,7 @@ var (
 	LimboRole    RoleType = "Limbo"
 	CompleteRole RoleType = "Complete"
 	ColorRole    RoleType = "Name Color"
+	C4XRole      RoleType = "C4X"
 )
 
 type Roles struct {


### PR DESCRIPTION
This PR adds encounter-based role selection menus based on what's configured in `config.yaml`.
Example `config.yaml` snippet that adds a "Reclear & C4X Roles" menu:
```yaml
guilds:
- name: NAUR
  roles:
    menu: true
...
  menu:
    - name: "menureclear"
      type: "encounter
      title: "Reclear & C4X Roles"
      description: >
        Cool description here
      roleType:
        - "Reclear"
        - "C4X"
      multiSelect: true
      requireClear: true
      roles:
        - name: "Extra role 1"
        - name: "Extra role 2"
```
Roles must be set up in the yaml under the encounters config too. Extra roles will not be affected by prerequisites since they are not connected to any encounters.
(Ignore the quotes, that's a simple fix with what I wrote in the YAML)
![image](https://github.com/user-attachments/assets/e2e2abae-c0c7-443f-9113-ea18e6a7ecd3)
![image](https://github.com/user-attachments/assets/12301217-ca85-4d42-956f-4c05e672a767)
![image](https://github.com/user-attachments/assets/3415ad4d-bf0f-41dd-85be-dce174b9777d)
![image](https://github.com/user-attachments/assets/6cb5f4f6-be21-43b5-b605-554d9a00ee03)
