### PR TITLE
Add menu button for Clearingway role removal

### DIFF
--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -289,6 +289,7 @@ func (g *Guild) InitDiscordMenu() {
 
 	// Remove Roles
 	dataMenuRemove := g.Menus.Menus[string(MenuRemove)]
+	dataMenuRemove.MenuRemoveInit()
 	customIDslice = []string{string(MenuRemove), string(CommandMenu)}
 	menuButtons = append(menuButtons, &discordgo.Button{
 		Label:    dataMenuRemove.Title,

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -211,10 +211,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},
@@ -253,10 +253,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-					{
-						Name: "FRU",
-						Value: "Futures Rewritten (Ultimate)",
-					},
+				{
+					Name: "FRU",
+					Value: "Futures Rewritten (Ultimate)",
+				},
 				*/
 			},
 		},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -211,10 +211,10 @@ var ReclearCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},
@@ -253,10 +253,10 @@ var NameColorCommand = &discordgo.ApplicationCommand{
 				},
 				// TODO: implement when FRU goes live
 				/*
-				{
-					Name: "FRU",
-					Value: "Futures Rewritten (Ultimate)",
-				},
+					{
+						Name: "FRU",
+						Value: "Futures Rewritten (Ultimate)",
+					},
 				*/
 			},
 		},

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -320,7 +320,6 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
 				return
 			}
-
 			switch CommandType(command[1]) {
 			case CommandMenu:
 				// send_encounter_menu(command[2])

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -307,13 +307,13 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		case MenuRemove:
 			switch CommandType(command[1]) {
 			case CommandMenu:
-				// send_menu()
+				c.MenuStaticRespond(s, i, command[0])
 			case CommandRemoveComfy:
-				// Uncomfy()
+				c.Uncomfy(s, i)
 			case CommandRemoveColor:
-				// Uncolor()
+				c.Uncolor(s, i)
 			case CommandRemoveAll:
-				// RemoveAll()
+				c.RemoveAll(s, i)
 			}
 		case MenuEncounter:
 			if ok := len(command) > 2; !ok {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -290,6 +290,11 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		c.Autocomplete(s, i)
 	case discordgo.InteractionMessageComponent:
 		customID := i.MessageComponentData().CustomID
+
+		// commands are differentiated by the customID with the format
+		// [menu type] [command type] [menu name]
+		// e.g "MenuEncounter encounterProcess menuProg"
+		// menu name is optional and only applies to encounter based menus for now
 		command := strings.Split(customID, " ")
 		if ok := len(command) > 1; !ok {
 			fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -2,6 +2,7 @@ package clearingway
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Veraticus/clearingway/internal/discord"
 	"github.com/bwmarrin/discordgo"
@@ -113,6 +114,58 @@ func (m *Menu) Init(c *ConfigMenu) {
 			data.ExtraRoles = append(data.ExtraRoles, role)
 		}
 	}
+}
+
+// Creates the menu component of MenuRemove
+func (m *Menu) MenuRemoveInit() {
+	type removeButton struct {
+		name        string
+		commandType CommandType
+	}
+
+	removeButtons := []discordgo.MessageComponent{}
+	removeButtonsList := []removeButton{
+		{name: "Uncomfy", commandType: CommandRemoveComfy},
+		{name: "Uncolor", commandType: CommandRemoveColor},
+		{name: "Remove All", commandType: CommandRemoveAll},
+	}
+
+	for _, button := range removeButtonsList {
+		customIDslice := []string{string(MenuRemove), string(button.commandType)}
+		removeButtons = append(removeButtons, discordgo.Button{
+			Label:    button.name,
+			Style:    discordgo.DangerButton,
+			Disabled: false,
+			CustomID: strings.Join(customIDslice, " "),
+		})
+	}
+
+	message := &discordgo.InteractionResponseData{
+		Flags: discordgo.MessageFlagsEphemeral,
+		Embeds: []*discordgo.MessageEmbed{
+			{
+				Title:       m.Title,
+				Description: m.Description,
+			},
+		},
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: removeButtons,
+			},
+		},
+	}
+
+	if len(m.ImageURL) > 0 {
+		message.Embeds[0].Image = &discordgo.MessageEmbedImage{URL: m.ImageURL}
+	}
+
+	m.AdditionalData = &MenuAdditionalData{
+		MessageEphemeral: &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: message,
+		},
+	}
+
 }
 
 func (g *Guild) DefaultMenus() {


### PR DESCRIPTION
Works exactly like the text based commands and just implements a GUI interface for them.
(Menu descriptions are placeholders)
![image](https://github.com/user-attachments/assets/385d6971-1481-431f-81ef-0e561cf1b7e0)
![image](https://github.com/user-attachments/assets/aa535376-312e-49f4-a1b7-ddbd04f3f73d)
![image](https://github.com/user-attachments/assets/4290bc63-2dfe-4eee-95c0-c568c6b458bf)
