### PR TITLE
Add buttons to remove categories of roles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -740,6 +740,7 @@ guilds:
       title: "NAUR Role Assignment"
       description: |-
         Welcome to the Role Assignment channel.
+        
         Using the buttons below will give or remove certain roles in this server. Some roles are tied to ultimate clears. Make sure to verify your clears for those roles. If you need any help or run into issues, please open a support ticket here: ⁠https://discord.com/channels/1172230157776466050/1241821383307038781
 
         **Verify Character**: Use this button to verify ownership and analyze all ultimate clears of your character.

--- a/config.yaml
+++ b/config.yaml
@@ -739,19 +739,19 @@ guilds:
       type: "menuMain"
       title: "NAUR Role Assignment"
       description: |-
-        Welcome to the Role Assignment channel. 
+        NAUR Role Assignment
 
-        To start, verify your character using the `Verify Character` button. After Clearingway has verified ownership of your character, you will receive roles based on certain criteria from your FFLogs. 
+        Welcome to the Role Assignment channel. Using the buttons below will give or remove certain roles in this server. Some roles are tied to ultimate clears. Make sure to verify your clears for those roles. If you need any help or run into issues, please open a support ticket here: ⁠https://discord.com/channels/1172230157776466050/1241821383307038781
 
-        Additional roles are also obtainable after verifying your character by using the other buttons. Descriptions for each button are provided below. You can also view every Clearingway related role by typing `/roles`.
+        **Verify Character**: Use this button to verify ownership and analyze all ultimate clears of your character.
 
-        **Verify Character**: Have Clearingway verify ownership and analyze all ultimate clears of your character.
-        **Reclear & C4X Roles**: Obtain mentionable Reclear or C4X Roles for a specific ultimate. You must have the corresponding Cleared Role.
-        **Legacy Content Roles**:  Obtain mentionable roles for legacy ultimate prog, ultimate unlocks, and or BiS farm parties.
-        **Change Name Color**: Obtain a role that changes your name color in NAUR to one that matches the theme of a specific ultimate. You must have the corresponding Cleared Role.
-        **Remove Roles**: Remove all or certain types of Clearingway related roles from yourself.
+        **Reclear & C4X Roles**: Use this button to add or remove specific Reclear or C4X Roles for a specific ultimate. You must have the corresponding Cleared Role.
 
-        If you need any help or run into issues, please open a support ticket here: <#1240061557350731856>
+        **Legacy Content Roles**: Use this button to add or remove specific mentionable roles for legacy ultimate prog, ultimate unlocks, and or BiS farm parties.
+
+        **Change Name Color**: Use this button to add or remove a specific role that changes your name color in NAUR to one that matches the theme of a specific ultimate. You must have the corresponding Cleared Role.
+
+        **Remove Roles**: Use this button to remove all or certain categories of roles from your profile.
     - name: "menuRemove"
       type: "menuRemove"
       title: "Remove Roles"

--- a/config.yaml
+++ b/config.yaml
@@ -739,9 +739,8 @@ guilds:
       type: "menuMain"
       title: "NAUR Role Assignment"
       description: |-
-        NAUR Role Assignment
-
-        Welcome to the Role Assignment channel. Using the buttons below will give or remove certain roles in this server. Some roles are tied to ultimate clears. Make sure to verify your clears for those roles. If you need any help or run into issues, please open a support ticket here: ⁠https://discord.com/channels/1172230157776466050/1241821383307038781
+        Welcome to the Role Assignment channel.
+        Using the buttons below will give or remove certain roles in this server. Some roles are tied to ultimate clears. Make sure to verify your clears for those roles. If you need any help or run into issues, please open a support ticket here: ⁠https://discord.com/channels/1172230157776466050/1241821383307038781
 
         **Verify Character**: Use this button to verify ownership and analyze all ultimate clears of your character.
 
@@ -761,7 +760,7 @@ guilds:
       type: "menuEncounter"
       title: "Reclear & C4X Roles"
       description: > 
-        Obtain mentionable Reclear or C4X Roles for a specific ultimate. You must have the corresponding Cleared Role.
+        Toggle mentionable Reclear or C4X Roles for a specific ultimate. You must have the corresponding Cleared Role.
       roleType:
         - "Reclear"
         - "C4X"
@@ -771,7 +770,7 @@ guilds:
       type: "menuEncounter"
       title: "Legacy Content Roles"
       description: >
-        Obtain mentionable roles for legacy ultimate prog, ultimate unlocks, and or BiS farm parties.
+        Toggle mentionable roles for legacy ultimate prog, ultimate unlocks, and or BiS farm parties.
       roleType:
         - "Prog"
       multiSelect: true
@@ -780,9 +779,9 @@ guilds:
         - name: "Ultimate Unlock"
     - name: "menuColor"
       type: "menuEncounter"
-      title: "Change Name Color"
+      title: "Name Color Roles"
       description: >
-        Obtain a role that changes your name color in NAUR to one that matches the theme of a specific ultimate. You must have the corresponding Cleared Role.
+        Toggle a role that changes your name color in NAUR to one that matches the theme of a specific ultimate. You must have the corresponding Cleared Role.
       roleType:
         - "Name Color"
       requireClear: true

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -331,7 +331,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 					fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
 					return
 				}
-				// can reuse this function since button interactions have no selections
+				// NB: can reuse this function since button interactions have no selections
 				c.MenuEncounterProcess(s, i, command[2])
 			}
 		case MenuEncounter:

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -47,6 +47,7 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			if menu.Type == MenuEncounter {
 				additionalData := menu.AdditionalData
 				menu.MenuEncounterInit(guild.Encounters, additionalData.RoleType)
+				guild.Menus.Menus[string(MenuRemove)].MenuRemoveAddButton(menu)
 			}
 		}
 
@@ -325,6 +326,13 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				c.Uncolor(s, i)
 			case CommandRemoveAll:
 				c.RemoveAll(s, i)
+			case CommandRemoveEncounter:
+				if ok := len(command) > 2; !ok {
+					fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
+					return
+				}
+				// can reuse this function since button interactions have no selections
+				c.MenuEncounterProcess(s, i, command[2])
 			}
 		case MenuEncounter:
 			if ok := len(command) > 2; !ok {

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -26,6 +26,7 @@ const (
 	CommandRemoveComfy      CommandType = "removeComfy"
 	CommandRemoveColor      CommandType = "removeColor"
 	CommandRemoveAll        CommandType = "removeAll"
+	CommandRemoveEncounter  CommandType = "removeEncounter"
 	CommandEncounterProcess CommandType = "encounterProcess"
 )
 
@@ -167,6 +168,28 @@ func (m *Menu) MenuRemoveInit() {
 		},
 	}
 
+}
+
+func (m *Menu) MenuRemoveAddButton(menuEncounterToAdd *Menu) {
+	// create button
+	customIDslice := []string{string(MenuRemove), string(CommandRemoveEncounter), string(menuEncounterToAdd.Name)}
+	button := discordgo.Button{
+		Label:    "Remove " + menuEncounterToAdd.Title,
+		Style:    discordgo.DangerButton,
+		Disabled: false,
+		CustomID: strings.Join(customIDslice, " "),
+	}
+
+	// create new ActionsRow component if already made, append to it
+	buttonRows := &m.AdditionalData.MessageEphemeral.Data.Components
+	if len(*buttonRows) < 2 {
+		*buttonRows = append(*buttonRows, discordgo.ActionsRow{Components: []discordgo.MessageComponent{button}})
+	} else {
+		// creates a copy of ActionsRow, appends the button, then sets the element to the appended copy
+		addButtonRow := (*buttonRows)[1].(discordgo.ActionsRow)
+		addButtonRow.Components = append(addButtonRow.Components, button)
+		(*buttonRows)[1] = addButtonRow
+	}
 }
 
 func (g *Guild) DefaultMenus() {


### PR DESCRIPTION
This PR adds buttons in the remove roles menu that lets the user remove categories of menu encounter roles set up in `config.yaml`, This PR also updates the menu descriptions for NAUR.

# New buttons
![image](https://github.com/user-attachments/assets/ff174235-a816-416e-97a4-f7e24a2341a4)
