### PR TITLE
Menu updates

### DIFF
--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -80,13 +80,21 @@ type ConfigReconfigureRoles struct {
 }
 
 type ConfigMenu struct {
-	Name         string        `yaml:"name"`
-	Type         string        `yaml:"type"`
-	Title        string        `yaml:"title"`
-	Description  string        `yaml:"description"`
-	ImageUrl     string        `yaml:"imageUrl"`
-	ConfigRoles  []*ConfigRole `yaml:"roles"`
-	RoleType     []string      `yaml:"roleType"`
-	MultiSelect  bool          `yaml:"multiSelect"`
-	RequireClear bool          `yaml:"requireClear"`
+	Name          string          `yaml:"name"`
+	Type          string          `yaml:"type"`
+	Title         string          `yaml:"title"`
+	Description   string          `yaml:"description"`
+	ImageUrl      string          `yaml:"imageUrl"`
+	ConfigButtons []*ConfigButton `yaml:"buttons"`
+	ConfigRoles   []*ConfigRole   `yaml:"roles"`
+	RoleType      []string        `yaml:"roleType"`
+	MultiSelect   bool            `yaml:"multiSelect"`
+	RequireClear  bool            `yaml:"requireClear"`
+}
+
+type ConfigButton struct {
+	Label    string `yaml:"label"`
+	Style    int    `yaml:"style"`
+	MenuName string `yaml:"menuName"`
+	MenuType string `yaml:"menuType"`
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -2,7 +2,6 @@ package clearingway
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Veraticus/clearingway/internal/ffxiv"
 	"github.com/bwmarrin/discordgo"
@@ -275,55 +274,28 @@ func (g *Guild) IsProgEnabled() bool {
 }
 
 func (g *Guild) InitDiscordMenu() {
-	dataMenuMain := g.Menus.Menus[string(MenuMain)]
-
-	// Verify Clears
-	dataMenuVerify := g.Menus.Menus[string(MenuVerify)]
-	customIDslice := []string{string(MenuVerify), string(CommandMenu)}
-	dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
-		Label:    dataMenuVerify.Title,
-		Style:    discordgo.SuccessButton,
-		Disabled: false,
-		CustomID: strings.Join(customIDslice, " "),
-	})
-
-	// Add yaml configured menus
+	// format the message object for main menus
 	for _, menu := range g.Menus.Menus {
-		if menu.Type == MenuEncounter {
-			customIDslice = []string{string(MenuEncounter), string(CommandMenu), menu.Name}
-			dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
-				Label:    menu.Title,
-				Style:    discordgo.PrimaryButton,
-				Disabled: false,
-				CustomID: strings.Join(customIDslice, " "),
-			})
+		if menu.Type != MenuMain {
+			continue
 		}
+
+		menuMessage := &discordgo.MessageSend{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       menu.Title,
+					Description: menu.Description,
+				},
+			},
+		}
+		if len(menu.ImageURL) > 0 {
+			menuMessage.Embeds[0].Image = &discordgo.MessageEmbedImage{URL: menu.ImageURL}
+		}
+		menu.AdditionalData = &MenuAdditionalData{MessageMainMenu: menuMessage}
+		menu.FinalizeButtons()
 	}
 
-	// Remove Roles
+	// initialize all buttons for remove roles
 	dataMenuRemove := g.Menus.Menus[string(MenuRemove)]
 	dataMenuRemove.MenuRemoveInit()
-	customIDslice = []string{string(MenuRemove), string(CommandMenu)}
-	dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
-		Label:    dataMenuRemove.Title,
-		Style:    discordgo.DangerButton,
-		Disabled: false,
-		CustomID: strings.Join(customIDslice, " "),
-	})
-
-	menuMessage := &discordgo.MessageSend{
-		Embeds: []*discordgo.MessageEmbed{
-			{
-				Title:       dataMenuMain.Title,
-				Description: dataMenuMain.Description,
-			},
-		},
-	}
-
-	if len(dataMenuMain.ImageURL) > 0 {
-		menuMessage.Embeds[0].Image = &discordgo.MessageEmbedImage{URL: dataMenuMain.ImageURL}
-	}
-
-	dataMenuMain.AdditionalData = &MenuAdditionalData{MessageMainMenu: menuMessage}
-	dataMenuMain.FinalizeButtons()
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Veraticus/clearingway/internal/ffxiv"
+	trie "github.com/Vivino/go-autocomplete-trie"
 	"github.com/bwmarrin/discordgo"
 )
 
@@ -274,6 +275,8 @@ func (g *Guild) IsProgEnabled() bool {
 }
 
 func (g *Guild) InitDiscordMenu() {
+	// init menu autocomplete
+	g.Menus.AutoCompleteTrie = trie.New()
 	// format the message object for main menus
 	for _, menu := range g.Menus.Menus {
 		if menu.Type != MenuMain {
@@ -293,6 +296,13 @@ func (g *Guild) InitDiscordMenu() {
 		}
 		menu.AdditionalData = &MenuAdditionalData{MessageMainMenu: menuMessage}
 		menu.FinalizeButtons()
+
+		// set up autocomplete
+		g.Menus.Autocomplete = append(g.Menus.Autocomplete, &discordgo.ApplicationCommandOptionChoice{
+			Name:  menu.Name,
+			Value: menu.Name,
+		})
+		g.Menus.AutoCompleteTrie.Insert(menu.Name)
 	}
 
 	// initialize all buttons for remove roles

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -275,12 +275,12 @@ func (g *Guild) IsProgEnabled() bool {
 }
 
 func (g *Guild) InitDiscordMenu() {
-	menuButtons := []discordgo.MessageComponent{}
+	dataMenuMain := g.Menus.Menus[string(MenuMain)]
 
 	// Verify Clears
 	dataMenuVerify := g.Menus.Menus[string(MenuVerify)]
 	customIDslice := []string{string(MenuVerify), string(CommandMenu)}
-	menuButtons = append(menuButtons, &discordgo.Button{
+	dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
 		Label:    dataMenuVerify.Title,
 		Style:    discordgo.SuccessButton,
 		Disabled: false,
@@ -291,9 +291,9 @@ func (g *Guild) InitDiscordMenu() {
 	for _, menu := range g.Menus.Menus {
 		if menu.Type == MenuEncounter {
 			customIDslice = []string{string(MenuEncounter), string(CommandMenu), menu.Name}
-			menuButtons = append(menuButtons, &discordgo.Button{
-				Label: menu.Title,
-				Style: discordgo.PrimaryButton,
+			dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
+				Label:    menu.Title,
+				Style:    discordgo.PrimaryButton,
 				Disabled: false,
 				CustomID: strings.Join(customIDslice, " "),
 			})
@@ -304,24 +304,18 @@ func (g *Guild) InitDiscordMenu() {
 	dataMenuRemove := g.Menus.Menus[string(MenuRemove)]
 	dataMenuRemove.MenuRemoveInit()
 	customIDslice = []string{string(MenuRemove), string(CommandMenu)}
-	menuButtons = append(menuButtons, &discordgo.Button{
+	dataMenuMain.Buttons = append(dataMenuMain.Buttons, discordgo.Button{
 		Label:    dataMenuRemove.Title,
 		Style:    discordgo.DangerButton,
 		Disabled: false,
 		CustomID: strings.Join(customIDslice, " "),
 	})
 
-	dataMenuMain := g.Menus.Menus[string(MenuMain)]
 	menuMessage := &discordgo.MessageSend{
 		Embeds: []*discordgo.MessageEmbed{
 			{
 				Title:       dataMenuMain.Title,
 				Description: dataMenuMain.Description,
-			},
-		},
-		Components: []discordgo.MessageComponent{
-			discordgo.ActionsRow{
-				Components: menuButtons,
 			},
 		},
 	}
@@ -331,4 +325,5 @@ func (g *Guild) InitDiscordMenu() {
 	}
 
 	dataMenuMain.AdditionalData = &MenuAdditionalData{MessageMainMenu: menuMessage}
+	dataMenuMain.FinalizeButtons()
 }

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -51,6 +51,14 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			}
 		}
 
+		for _, menu := range guild.Menus.Menus {
+			if menu.Type == MenuMain || menu.Type == MenuRemove {
+				if len(menu.Buttons) != 0 {
+					menu.FinalizeButtons()
+				}
+			}
+		}
+
 		time.Sleep(1 * time.Second)
 
 		fmt.Printf("Adding commands...")

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -118,10 +118,11 @@ var MenuCommand = &discordgo.ApplicationCommand{
 	DefaultMemberPermissions: &adminPermission,
 	Options: []*discordgo.ApplicationCommandOption{
 		{
-			Type:        discordgo.ApplicationCommandOptionString,
-			Name:        "menu",
-			Description: "Menu to send",
-			Required:    true,
+			Type:         discordgo.ApplicationCommandOptionString,
+			Name:         "menu",
+			Description:  "Menu to send",
+			Required:     true,
+			Autocomplete: true,
 		},
 	},
 }
@@ -306,7 +307,12 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			c.MenuMainSend(s, i)
 		}
 	case discordgo.InteractionApplicationCommandAutocomplete:
-		c.Autocomplete(s, i)
+		switch i.ApplicationCommandData().Name {
+		case "clears":
+			c.Autocomplete(s, i)
+		case "menu":
+			c.MenuAutocomplete(s, i)
+		}
 	case discordgo.InteractionMessageComponent:
 		customID := i.MessageComponentData().CustomID
 

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -116,6 +116,14 @@ var MenuCommand = &discordgo.ApplicationCommand{
 	Name:                     "menu",
 	Description:              "Send the roles menu to the current channel.",
 	DefaultMemberPermissions: &adminPermission,
+	Options: []*discordgo.ApplicationCommandOption{
+		{
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "menu",
+			Description: "Menu to send",
+			Required:    true,
+		},
+	},
 }
 
 var ClearCommand = &discordgo.ApplicationCommand{

--- a/internal/clearingway/menu-main.go
+++ b/internal/clearingway/menu-main.go
@@ -15,7 +15,16 @@ func (c *Clearingway) MenuMainSend(s *discordgo.Session, i *discordgo.Interactio
 		return
 	}
 
-	menu := g.Menus.Menus[string(MenuMain)]
+	menuOpt := i.ApplicationCommandData().Options[0].StringValue()
+
+	menu, ok := g.Menus.Menus[menuOpt]
+	if !ok {
+		err := discord.StartInteraction(s, i.Interaction, "Unable to find menu.")
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+		}
+		return
+	}
 	additionalData := menu.AdditionalData
 
 	_, err := s.ChannelMessageSendComplex(i.ChannelID, additionalData.MessageMainMenu)

--- a/internal/clearingway/menu-main.go
+++ b/internal/clearingway/menu-main.go
@@ -27,6 +27,14 @@ func (c *Clearingway) MenuMainSend(s *discordgo.Session, i *discordgo.Interactio
 	}
 	additionalData := menu.AdditionalData
 
+	if menu.Type != MenuMain {
+		err := discord.StartInteraction(s, i.Interaction, "Menu is not of type menuMain.")
+		if err != nil {
+			fmt.Printf("Error sending Discord message: %v\n", err)
+		}
+		return
+	}
+
 	_, err := s.ChannelMessageSendComplex(i.ChannelID, additionalData.MessageMainMenu)
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)

--- a/internal/clearingway/menu-remove.go
+++ b/internal/clearingway/menu-remove.go
@@ -13,7 +13,7 @@ func (m *Menu) MenuRemoveInit() {
 		commandType CommandType
 	}
 
-	removeButtons := []discordgo.MessageComponent{}
+	removeButtons := []discordgo.Button{}
 	removeButtonsList := []removeButton{
 		{name: "Uncomfy", commandType: CommandRemoveComfy},
 		{name: "Uncolor", commandType: CommandRemoveColor},
@@ -30,17 +30,14 @@ func (m *Menu) MenuRemoveInit() {
 		})
 	}
 
+	m.Buttons = append(m.Buttons, removeButtons...)
+
 	message := &discordgo.InteractionResponseData{
 		Flags: discordgo.MessageFlagsEphemeral,
 		Embeds: []*discordgo.MessageEmbed{
 			{
 				Title:       m.Title,
 				Description: m.Description,
-			},
-		},
-		Components: []discordgo.MessageComponent{
-			discordgo.ActionsRow{
-				Components: removeButtons,
 			},
 		},
 	}
@@ -68,14 +65,5 @@ func (m *Menu) MenuRemoveAddButton(menuEncounterToAdd *Menu) {
 		CustomID: strings.Join(customIDslice, " "),
 	}
 
-	// create new ActionsRow component if already made, append to it
-	buttonRows := &m.AdditionalData.MessageEphemeral.Data.Components
-	if len(*buttonRows) < 2 {
-		*buttonRows = append(*buttonRows, discordgo.ActionsRow{Components: []discordgo.MessageComponent{button}})
-	} else {
-		// creates a copy of ActionsRow, appends the button, then sets the element to the appended copy
-		addButtonRow := (*buttonRows)[1].(discordgo.ActionsRow)
-		addButtonRow.Components = append(addButtonRow.Components, button)
-		(*buttonRows)[1] = addButtonRow
-	}
+	m.Buttons = append(m.Buttons, button)
 }

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -2,6 +2,7 @@ package clearingway
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -74,6 +75,44 @@ func (m *Menu) Init(c *ConfigMenu) {
 	}
 
 	switch m.Type {
+	case MenuMain:
+		for _, configButton := range c.ConfigButtons {
+			button := discordgo.Button{}
+
+			if len(configButton.Label) != 0 {
+				button.Label = configButton.Label
+			} else {
+				continue
+			}
+
+			if configButton.Style != 0 {
+				button.Style = discordgo.ButtonStyle(configButton.Style)
+			} else {
+				button.Style = discordgo.ButtonStyle(1)
+			}
+
+			customIDslice := []string{}
+			if len(configButton.MenuName) != 0 && len(configButton.MenuType) != 0 {
+				menuType := MenuType(configButton.MenuType)
+				switch menuType {
+				case MenuVerify:
+					fallthrough
+				case MenuRemove:
+					customIDslice = []string{configButton.MenuType, string(CommandMenu)}
+				case MenuEncounter:
+					customIDslice = []string{string(MenuEncounter), string(CommandMenu), configButton.MenuName}
+
+				default:
+					continue
+				}
+			} else {
+				continue
+			}
+			button.Disabled = false
+			button.CustomID = strings.Join(customIDslice, " ")
+
+			m.Buttons = append(m.Buttons, button)
+		}
 	case MenuEncounter:
 		m.AdditionalData = &MenuAdditionalData{}
 		data := m.AdditionalData


### PR DESCRIPTION
Dependent on #45 
This PR allows for multiple main menus to be configured in `config.yaml`.
Since there are multiple main menus now, the Discord command `/menu` now has an added argument to specify which menu to send to the channel.
~~TBD: README for menu configuration~~ README moved to style PR