### PR TITLE
Update c4x role menu

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -819,6 +819,8 @@ guilds:
         corresponding Cleared Role.
       roleType:
         - C4X
+      multiSelect: true
+      requireClear: true
     - name: prog
       type: menuMain
       title: __Prog Role Menu__


### PR DESCRIPTION
Fixes a bug where all C4X roles are mutually exclusive instead of being able to select multiple