### PR TITLE
Update menus to handle multiple difficulties

### DIFF
--- a/README-menus.md
+++ b/README-menus.md
@@ -49,7 +49,7 @@ A list of buttons to be displayed under the embed. Each button object has the fo
 ## MenuEncounter
 Ephemeral response menus that allow the user to pick role(s) through a dropdown selection. Dropdown can be single option or multi option. 
 
-Roles in this menu can be set up 2 ways, for all ultimate encounters or a per-role basis. The former allows for requiring a cleared role for the respective ultimate. The latter allows to add miscellaneous roles that are connected to Clearingway's internal encounters.
+Roles in this menu can be set up 2 ways, for all encounters of a particular difficulty or a per-role basis. The former allows for requiring a cleared role for the respective ultimate. The latter allows to add miscellaneous roles that are connected to Clearingway's internal encounters.
 
 ### Common
 #### Optional properties
@@ -60,6 +60,7 @@ Roles must still be set up separately and connected the respective encounter in 
 #### Required properties
 - `roleType` (array of string) - Category of role (string enum), defined in `role.go`
 #### Optional properties
+- `difficulties` (array of string) - Encounter difficulties you want to include in this menu.
 - `requireClear` (bool) - Whether the configured roles require their respective encounter's clear role.
 
 ### Per-role basis
@@ -220,3 +221,63 @@ Here I add 1 more encounter and another role type, now I have 2 different select
       requireClear: true
       multiSelect: true
 ```
+## Role menu for only one dificulty type
+Use this when you want to filter out encounters of certain difficulties. 
+```yaml
+# ...
+  encounters:
+    # test encounter 1
+    - ids: [1234]
+      name: "Test encounter 1"
+      difficulty: "Ultimate"
+      roles:
+        # ...
+    - ids: [2345]
+      name: "Test encounter 2"
+      difficulty: "Savage"
+      roles:
+        # ...
+  menu:
+    # ... menuMain with the respective button ...
+    # reclear/c4x submenu
+    - name: "namecolors"
+      type: "menuEncounter"
+      title: "Name Color Roles"
+      description: "Name Color Roles"
+      roleType:
+        - Name Color
+      requireClear: true
+      difficulties:
+        - Ultimate
+```
+The menu now only contains the relevant role of test encounter 1, test encounter 2 is filtered out.
+## Role menu with multiple difficulty types but split in the same menu
+```yaml
+# ...
+  encounters:
+    # test encounter 1
+    - ids: [1234]
+      name: "Test encounter 1"
+      difficulty: "Ultimate"
+      roles:
+        # ...
+    - ids: [2345]
+      name: "Test encounter 2"
+      difficulty: "Savage"
+      roles:
+        # ...
+  menu:
+    # ... menuMain with the respective button ...
+    # reclear/c4x submenu
+    - name: "namecolors"
+      type: "menuEncounter"
+      title: "Name Color Roles"
+      description: "Name Color Roles"
+      roleType:
+        - Name Color
+      requireClear: true
+      difficulties:
+        - Ultimate
+        - Savage
+```
+The menu now contains the relevant roles for both encounters, but they are split for better categorization.

--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -92,6 +92,7 @@ type ConfigMenu struct {
 	RoleType      []string        `yaml:"roleType"`
 	MultiSelect   bool            `yaml:"multiSelect"`
 	RequireClear  bool            `yaml:"requireClear"`
+	Difficulties  []string        `yaml:"difficulties"`
 }
 
 type ConfigButton struct {

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -348,7 +348,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 					return
 				}
 				// NB: can reuse this function since button interactions have no selections
-				c.MenuEncounterProcess(s, i, command[2])
+				c.MenuEncounterProcess(s, i, command[2], "-1")
 			}
 		case MenuEncounter:
 			if ok := len(command) > 2; !ok {
@@ -359,7 +359,7 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 			case CommandMenu:
 				c.MenuEncounterSend(s, i, command[2])
 			case CommandEncounterProcess:
-				c.MenuEncounterProcess(s, i, command[2])
+				c.MenuEncounterProcess(s, i, command[2], command[3])
 			}
 		}
 	case discordgo.InteractionModalSubmit:

--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -317,9 +317,9 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 		customID := i.MessageComponentData().CustomID
 
 		// commands are differentiated by the customID with the format
-		// [menu type] [command type] [menu name]
-		// e.g "MenuEncounter encounterProcess menuProg"
-		// menu name is optional and only applies to encounter based menus for now
+		// [menu type] [command type] [menu name] [dropdownId]
+		// e.g "MenuEncounter encounterProcess menuProg 0"
+		// menu name and dropdownId are optional and only applies to encounter based menus for now
 		command := strings.Split(customID, " ")
 		if ok := len(command) > 1; !ok {
 			fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)

--- a/internal/clearingway/menu-encounter.go
+++ b/internal/clearingway/menu-encounter.go
@@ -2,20 +2,48 @@ package clearingway
 
 import (
 	"fmt"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/Veraticus/clearingway/internal/discord"
 	"github.com/bwmarrin/discordgo"
 )
 
+const DEFAULT_TITLE = "General"
+
 func (m *Menu) MenuEncounterInit(es *Encounters, roleTypes []RoleType) {
 	additionalData := m.AdditionalData
 	additionalData.Roles = make(map[string]*MenuRoleHelper)
-	dropdownSlice := []discordgo.SelectMenuOption{}
+	dropdownSlice := []DropdownHelper{}
+	difficultyToIndex := make(map[string]int)
+
+	// populate individual SelectMenus
+	if len(additionalData.Difficulties) > 0 {
+		for index, difficulty := range additionalData.Difficulties {
+			dropdownSlice = append(dropdownSlice, DropdownHelper{
+				DropdownTitle:     difficulty,
+				SelectMenuOptions: []discordgo.SelectMenuOption{},
+			})
+			difficultyToIndex[difficulty] = index
+		}
+	} else if len(roleTypes) > 0 {
+		// if no difficulties specified but role types are specified, populate a single SelectMenu
+		dropdownSlice = append(dropdownSlice, DropdownHelper{
+			DropdownTitle:     DEFAULT_TITLE,
+			SelectMenuOptions: []discordgo.SelectMenuOption{},
+		})
+		difficultyToIndex[DEFAULT_TITLE] = 0
+	}
 
 	// generate options based on encounters
 	for _, roleType := range roleTypes {
 		for _, encounter := range es.Encounters {
+			// skip encounter if menu does not include encounter's difficulty when explicitly specified
+			if len(additionalData.Difficulties) > 0 && !slices.Contains(additionalData.Difficulties, encounter.Difficulty) {
+				continue
+			}
+
 			role, ok := encounter.Roles[roleType]
 			if !ok {
 				fmt.Printf("Menu %v: role type %v for encounter %v not found. Skipping...\n", m.Name, string(roleType), encounter.Name)
@@ -38,9 +66,28 @@ func (m *Menu) MenuEncounterInit(es *Encounters, roleTypes []RoleType) {
 				}
 			}
 
-			dropdownSlice = append(dropdownSlice, dropdownOption)
+			// if difficulties are specified, put them into their respective selectMenu
+			if len(additionalData.Difficulties) != 0 {
+				difficultyIndex := difficultyToIndex[encounter.Difficulty]
+				menuRoleHelper.DifficultyIndex = difficultyIndex
+				dropdownToAppend := &dropdownSlice[difficultyIndex]
+				dropdownToAppend.SelectMenuOptions = append(dropdownToAppend.SelectMenuOptions, dropdownOption)
+			} else {
+				dropdownSlice[0].SelectMenuOptions = append(dropdownSlice[0].SelectMenuOptions, dropdownOption)
+			}
+
 			additionalData.Roles[role.DiscordRole.ID] = menuRoleHelper
 		}
+	}
+
+	// if there are additional roles, make a new SelectMenu for it
+	extraRolesIndex := 0
+	if len(additionalData.ExtraRoles) != 0 {
+		dropdownSlice = append(dropdownSlice, DropdownHelper{
+			DropdownTitle:     "Others",
+			SelectMenuOptions: []discordgo.SelectMenuOption{},
+		})
+		extraRolesIndex = len(dropdownSlice) - 1
 	}
 
 	// generate options based on additional roles
@@ -55,7 +102,7 @@ func (m *Menu) MenuEncounterInit(es *Encounters, roleTypes []RoleType) {
 			Role: role,
 		}
 
-		dropdownSlice = append(dropdownSlice, dropdownOption)
+		dropdownSlice[extraRolesIndex].SelectMenuOptions = append(dropdownSlice[extraRolesIndex].SelectMenuOptions, dropdownOption)
 		additionalData.Roles[role.DiscordRole.ID] = menuRoleHelper
 	}
 
@@ -82,59 +129,94 @@ func (c *Clearingway) MenuEncounterSend(s *discordgo.Session, i *discordgo.Inter
 	}
 	additionalData := menu.AdditionalData
 
-	dropdownSlice := make([]discordgo.SelectMenuOption, len(additionalData.EncounterDropdown))
-	copy(dropdownSlice, additionalData.EncounterDropdown)
+	dropdowns := make([]DropdownHelper, len(additionalData.EncounterDropdown))
+	copy(dropdowns, additionalData.EncounterDropdown)
 
 	// set default selections based on roles present
-	for i, _ := range dropdownSlice {
-		option := &dropdownSlice[i]
-		if _, ok := userRoleMap[option.Value]; ok {
-			option.Default = true
+	for index, dropdown := range dropdowns {
+		for selectMenuOption, _ := range dropdown.SelectMenuOptions {
+			option := &dropdowns[index].SelectMenuOptions[selectMenuOption]
+			if _, ok := userRoleMap[option.Value]; ok {
+				option.Default = true
+			}
 		}
 	}
 
-	// generate role list description
-	descriptionRoleList := "\n### Available roles"
-	for _, role := range dropdownSlice {
-		descriptionRoleList += fmt.Sprintf("\n- <@&%s>", role.Value)
+	// generate role list descriptions
+	descriptionRoleList := []string{}
+	for index, dropdown := range dropdowns {
+		descriptionRoleList = append(descriptionRoleList, "")
+		for _, role := range dropdown.SelectMenuOptions {
+			descriptionRoleList[index] += fmt.Sprintf("\n- <@&%s>", role.Value)
+		}
 	}
 
 	minValues := 0
-	maxValues := 1
+	maxValues := []int{}
 
 	if additionalData.MultiSelect {
-		maxValues = len(dropdownSlice)
+		for _, dropdown := range dropdowns {
+			maxValues = append(maxValues, len(dropdown.SelectMenuOptions))
+		}
+	} else {
+		for _, _ = range dropdowns {
+			maxValues = append(maxValues, 1)
+		}
 	}
 
 	// format response message
-	customID := []string{string(MenuEncounter), string(CommandEncounterProcess), menuName}
-	dropdownMenu := discordgo.SelectMenu{
-		MenuType:  discordgo.StringSelectMenu,
-		CustomID:  strings.Join(customID, " "),
-		Options:   dropdownSlice,
-		MinValues: &minValues,
-		MaxValues: maxValues,
+	baseCustomID := []string{string(MenuEncounter), string(CommandEncounterProcess), menuName}
+	fields := []*discordgo.MessageEmbedField{}
+	components := []discordgo.MessageComponent{}
+
+	for index, dropdown := range dropdowns {
+		// add individual SelectMenus to message
+		dropdownCustomID := append(baseCustomID, strconv.Itoa(index))
+		components = append(components, discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					MenuType:  discordgo.StringSelectMenu,
+					CustomID:  strings.Join(dropdownCustomID, " "),
+					Options:   dropdown.SelectMenuOptions,
+					MinValues: &minValues,
+					MaxValues: maxValues[index],
+				},
+			},
+		})
+
+		// if there's more than one dropdown, add the role list descriptions to a field
+		if len(dropdowns) > 1 {
+			fields = append(fields, &discordgo.MessageEmbedField{
+				Name:   dropdown.DropdownTitle,
+				Value:  descriptionRoleList[index],
+				Inline: true,
+			})
+		}
 	}
 
 	menu = g.Menus.Menus[menuName]
+	description := menu.Description + "\n### Available roles"
+
+	embed := []*discordgo.MessageEmbed{
+		{
+			Title:       menu.Title,
+			Description: description,
+		},
+	}
+
+	// if there's only one dropdown, add the role list descriptions to the main description
+	if len(dropdowns) == 1 {
+		embed[0].Description += descriptionRoleList[0]
+	} else {
+		embed[0].Fields = fields
+	}
 
 	message := &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
-			Flags: discordgo.MessageFlagsEphemeral,
-			Embeds: []*discordgo.MessageEmbed{
-				{
-					Title:       menu.Title,
-					Description: menu.Description + descriptionRoleList,
-				},
-			},
-			Components: []discordgo.MessageComponent{
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						dropdownMenu,
-					},
-				},
-			},
+			Flags:      discordgo.MessageFlagsEphemeral,
+			Embeds:     embed,
+			Components: components,
 		},
 	}
 
@@ -148,7 +230,7 @@ func (c *Clearingway) MenuEncounterSend(s *discordgo.Session, i *discordgo.Inter
 
 }
 
-func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.InteractionCreate, menuName string) {
+func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.InteractionCreate, menuName string, menuIndexString string) {
 	err := discord.StartInteraction(s, i.Interaction, "Processing request...")
 	if err != nil {
 		fmt.Printf("Error sending Discord message: %v\n", err)
@@ -167,7 +249,6 @@ func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.In
 		return
 	}
 	additionalData := menu.AdditionalData
-
 	userOptions := i.MessageComponentData().Values
 	userOptionsMap := make(map[string]struct{})
 	for _, opt := range userOptions {
@@ -180,19 +261,43 @@ func (c *Clearingway) MenuEncounterProcess(s *discordgo.Session, i *discordgo.In
 		userRolesMap[roleId] = struct{}{}
 	}
 
-	// check which roles to add or remove
+	// menuIndex specifies the index of the SelectMenu
+	// indicates what roles are relevant
+	menuIndex, err := strconv.Atoi(menuIndexString)
+	if err != nil {
+		discord.StartInteraction(s, i.Interaction, "Error: Invalid custom ID.")
+		return
+	}
+
 	rolesToAdd := []*MenuRoleHelper{}
 	rolesToRemove := []*Role{}
-	for _, roleHelper := range additionalData.Roles {
-		role := roleHelper.Role
+	if menuIndex < 0 {
+		// menuIndex of -1 = remove roles buttons
+		for _, roleHelper := range additionalData.Roles {
+			role := roleHelper.Role
 
-		_, selected := userOptionsMap[role.DiscordRole.ID]
-		_, present := userRolesMap[role.DiscordRole.ID]
+			_, present := userRolesMap[role.DiscordRole.ID]
 
-		if selected && !present {
-			rolesToAdd = append(rolesToAdd, roleHelper)
-		} else if !selected && present {
-			rolesToRemove = append(rolesToRemove, role)
+			if present {
+				rolesToRemove = append(rolesToRemove, role)
+			}
+		}
+	} else {
+		// check which roles to add or remove
+		rolesInDifficulty := additionalData.EncounterDropdown[menuIndex]
+		for _, selectMenuOption := range rolesInDifficulty.SelectMenuOptions {
+			roleID := selectMenuOption.Value
+			roleHelper := additionalData.Roles[roleID]
+			role := roleHelper.Role
+
+			_, selected := userOptionsMap[role.DiscordRole.ID]
+			_, present := userRolesMap[role.DiscordRole.ID]
+
+			if selected && !present {
+				rolesToAdd = append(rolesToAdd, roleHelper)
+			} else if !selected && present {
+				rolesToRemove = append(rolesToRemove, role)
+			}
 		}
 	}
 

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -50,19 +50,26 @@ type Menu struct {
 }
 
 type MenuRoleHelper struct {
-	Role         *Role
-	Prerequisite *Role
+	Role            *Role
+	Prerequisite    *Role
+	DifficultyIndex int
+}
+
+type DropdownHelper struct {
+	DropdownTitle     string
+	SelectMenuOptions []discordgo.SelectMenuOption
 }
 
 type MenuAdditionalData struct {
 	MessageMainMenu   *discordgo.MessageSend
 	MessageEphemeral  *discordgo.InteractionResponse
-	EncounterDropdown []discordgo.SelectMenuOption
+	EncounterDropdown []DropdownHelper
 	Roles             map[string]*MenuRoleHelper
 	ExtraRoles        []*Role
 	RoleType          []RoleType
 	MultiSelect       bool
 	RequireClear      bool
+	Difficulties      []string
 }
 
 func (m *Menu) Init(c *ConfigMenu) {
@@ -153,6 +160,10 @@ func (m *Menu) Init(c *ConfigMenu) {
 			data.RequireClear = true
 		} else {
 			data.RequireClear = false
+		}
+
+		if len(c.Difficulties) != 0 {
+			data.Difficulties = c.Difficulties
 		}
 
 		for _, configRole := range c.ConfigRoles {


### PR DESCRIPTION
This PR updates menus to be able to handle multiple difficulties in encounters. Since NASE may (will?) be merging into NAUR, we need to support multiple difficulties. Splitting these will help with the organization for the menu.
![image](https://github.com/user-attachments/assets/19a33d37-8aee-46bc-a793-6deb030e9842)
