### PR TITLE
Fix roles being preselected when they were not supposed to

### DIFF
--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -360,7 +360,11 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				c.MenuEncounterSend(s, i, command[2])
 			case CommandEncounterProcess:
 				c.MenuEncounterProcess(s, i, command[2], command[3])
-			}
+			default:
+				fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
+			}	
+		default:
+			fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
 		}
 	case discordgo.InteractionModalSubmit:
 		customID := i.ModalSubmitData().CustomID

--- a/internal/clearingway/menu-encounter.go
+++ b/internal/clearingway/menu-encounter.go
@@ -129,8 +129,17 @@ func (c *Clearingway) MenuEncounterSend(s *discordgo.Session, i *discordgo.Inter
 	}
 	additionalData := menu.AdditionalData
 
+	// make deep copy of DropdownHelper slice
 	dropdowns := make([]DropdownHelper, len(additionalData.EncounterDropdown))
-	copy(dropdowns, additionalData.EncounterDropdown)
+	for i, dropdown := range additionalData.EncounterDropdown {
+		selectMenuOptCopy := make([]discordgo.SelectMenuOption, len(dropdown.SelectMenuOptions))
+		copy(selectMenuOptCopy, dropdown.SelectMenuOptions)
+
+		dropdowns[i] = DropdownHelper{
+			DropdownTitle:     dropdown.DropdownTitle,
+			SelectMenuOptions: selectMenuOptCopy,
+		}
+	}
 
 	// set default selections based on roles present
 	for index, dropdown := range dropdowns {


### PR DESCRIPTION
Roles were being pre-selected when they weren't supposed to as the last PR created a new struct which contained the original `[]SelectMenuOption` slices in one of its variables. Since `copy()` only makes a shallow copy, the `[]SelectMenuOption` in the copied struct points to the original, so any role that was set to 1 will stay that way in all interactions.

I believe this is the source of error for name colors not working too. Since it has a max selection limit of 1 role, having multiple roles pre-selected would probably cause Discord to complain. If this doesn't solve the issue, I added some error statements to help debug