### PR TITLE
Add grouped menus

### DIFF
--- a/README-menus.md
+++ b/README-menus.md
@@ -281,3 +281,25 @@ The menu now only contains the relevant role of test encounter 1, test encounter
         - Savage
 ```
 The menu now contains the relevant roles for both encounters, but they are split for better categorization.
+
+# Menu groups
+You can send multiple menus with one /menu command by setting up a menu group.  
+The following creates a single menu group called "roleAssignment" and sends
+the menuMains corresponding to the 3 items in order. The group will show up
+as an autocomplete option in /menu as "group roleAssignment"
+```yaml
+guilds:
+- name: guild name
+  roles:
+    menu: true
+  guildId: 1234567891234567891
+  channelId: 1234567891234567891
+  menuOrder:
+    - name: "roleAssignment"
+      menus:
+        - menuMain
+        - cleared
+        - prog
+  menu:
+    # ...
+```

--- a/internal/clearingway/config.go
+++ b/internal/clearingway/config.go
@@ -14,6 +14,7 @@ type ConfigGuild struct {
 	ConfigRoles               *ConfigRoles                `yaml:"roles"`
 	ConfigReconfigureRoles    []*ConfigReconfigureRoles   `yaml:"reconfigureRoles"`
 	ConfigMenus               []*ConfigMenu               `yaml:"menu"`
+	ConfigMenuOrder           []ConfigMenuOrder           `yaml:"menuOrder"`
 }
 
 type ConfigRoles struct {
@@ -106,4 +107,9 @@ type ConfigField struct {
 	Name   string `yaml:"name"`
 	Value  string `yaml:"value"`
 	Inline bool   `yaml:"inline"`
+}
+
+type ConfigMenuOrder struct {
+	Name  string   `yaml:"name"`
+	Menus []string `yaml:"menus"`
 }

--- a/internal/clearingway/guild.go
+++ b/internal/clearingway/guild.go
@@ -53,7 +53,7 @@ func (g *Guild) Init(c *ConfigGuild) {
 	g.Encounters = &Encounters{Encounters: []*Encounter{}}
 	g.Achievements = &Achievements{Achievements: []*Achievement{}}
 	g.Characters = &ffxiv.Characters{Characters: map[string]*ffxiv.Character{}}
-	g.Menus = &Menus{Menus: map[string]*Menu{}}
+	g.Menus = &Menus{Menus: map[string]*Menu{}, MenuGroups: map[string][]string{}}
 	g.DefaultMenus()
 
 	g.PhysicalDatacenters = &PhysicalDatacenters{PhysicalDatacenters: map[string]*PhysicalDatacenter{}}
@@ -178,6 +178,12 @@ func (g *Guild) Init(c *ConfigGuild) {
 	}
 
 	if g.MenuEnabled {
+		if (c.ConfigMenuOrder != nil) {
+			for _, menuOrder := range c.ConfigMenuOrder {
+				g.Menus.MenuGroups[menuOrder.Name] = menuOrder.Menus
+			}
+		}
+		
 		g.InitDiscordMenu()
 		g.MenuRoles = g.Menus.Roles()
 	}
@@ -303,6 +309,15 @@ func (g *Guild) InitDiscordMenu() {
 			Value: menu.Name,
 		})
 		g.Menus.AutoCompleteTrie.Insert(menu.Name)
+	}
+
+	for group, _ := range g.Menus.MenuGroups {
+		menuGroupName := "group " + group
+		g.Menus.Autocomplete = append(g.Menus.Autocomplete, &discordgo.ApplicationCommandOptionChoice{
+			Name: menuGroupName,
+			Value: menuGroupName,
+		})
+		g.Menus.AutoCompleteTrie.Insert(menuGroupName)
 	}
 
 	// initialize all buttons for remove roles

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -35,6 +35,7 @@ type Menus struct {
 	Menus            map[string]*Menu
 	Autocomplete     []*discordgo.ApplicationCommandOptionChoice
 	AutoCompleteTrie *trie.Trie
+	MenuGroups        map[string][]string
 }
 
 type Menu struct {


### PR DESCRIPTION
This PR adds grouped menus, so we don't have to individually send each menu 1 by 1.
We can now define multiple groups in the config. They will then appear in the /menu autocomplete as "group [groupName]".