### PR TITLE
Remove all "remove [role]" buttons except remove all

### DIFF
--- a/internal/clearingway/handlers.go
+++ b/internal/clearingway/handlers.go
@@ -47,7 +47,6 @@ func (c *Clearingway) DiscordReady(s *discordgo.Session, event *discordgo.Ready)
 			if menu.Type == MenuEncounter {
 				additionalData := menu.AdditionalData
 				menu.MenuEncounterInit(guild.Encounters, additionalData.RoleType)
-				guild.Menus.Menus[string(MenuRemove)].MenuRemoveAddButton(menu)
 			}
 		}
 
@@ -342,13 +341,6 @@ func (c *Clearingway) InteractionCreate(s *discordgo.Session, i *discordgo.Inter
 				c.Uncolor(s, i)
 			case CommandRemoveAll:
 				c.RemoveAll(s, i)
-			case CommandRemoveEncounter:
-				if ok := len(command) > 2; !ok {
-					fmt.Printf("Invalid custom ID received: \"%v\"\n", customID)
-					return
-				}
-				// NB: can reuse this function since button interactions have no selections
-				c.MenuEncounterProcess(s, i, command[2], "-1")
 			}
 		case MenuEncounter:
 			if ok := len(command) > 2; !ok {

--- a/internal/clearingway/menu-remove.go
+++ b/internal/clearingway/menu-remove.go
@@ -8,27 +8,14 @@ import (
 
 // Creates the menu component of MenuRemove
 func (m *Menu) MenuRemoveInit() {
-	type removeButton struct {
-		name        string
-		commandType CommandType
-	}
-
-	removeButtons := []discordgo.Button{}
-	removeButtonsList := []removeButton{
-		// TODO: implement manual disabling of these buttons through the config
-		{name: "Uncomfy", commandType: CommandRemoveComfy},
-		//{name: "Uncolor", commandType: CommandRemoveColor},
-		{name: "Remove All", commandType: CommandRemoveAll},
-	}
-
-	for _, button := range removeButtonsList {
-		customIDslice := []string{string(MenuRemove), string(button.commandType)}
-		removeButtons = append(removeButtons, discordgo.Button{
-			Label:    button.name,
-			Style:    discordgo.DangerButton,
+	removeAllCustomID := []string{string(MenuRemove), string(CommandRemoveAll)}
+	removeButtons := []discordgo.Button{
+		{
+			Label:   "Yes, remove all roles",
+			Style: discordgo.DangerButton,
 			Disabled: false,
-			CustomID: strings.Join(customIDslice, " "),
-		})
+			CustomID: strings.Join(removeAllCustomID, " "),
+		},
 	}
 
 	m.Buttons = append(m.Buttons, removeButtons...)
@@ -51,18 +38,4 @@ func (m *Menu) MenuRemoveInit() {
 			Data: message,
 		},
 	}
-
-}
-
-func (m *Menu) MenuRemoveAddButton(menuEncounterToAdd *Menu) {
-	// create button
-	customIDslice := []string{string(MenuRemove), string(CommandRemoveEncounter), string(menuEncounterToAdd.Name)}
-	button := discordgo.Button{
-		Label:    "Remove " + menuEncounterToAdd.Title,
-		Style:    discordgo.DangerButton,
-		Disabled: false,
-		CustomID: strings.Join(customIDslice, " "),
-	}
-
-	m.Buttons = append(m.Buttons, button)
 }

--- a/internal/clearingway/menu.go
+++ b/internal/clearingway/menu.go
@@ -26,6 +26,7 @@ const (
 	CommandRemoveComfy      CommandType = "removeComfy"
 	CommandRemoveColor      CommandType = "removeColor"
 	CommandRemoveAll        CommandType = "removeAll"
+	CommandRemoveCancel     CommandType = "removeCancel"
 	CommandRemoveEncounter  CommandType = "removeEncounter"
 	CommandEncounterProcess CommandType = "encounterProcess"
 )
@@ -205,8 +206,8 @@ func (g *Guild) DefaultMenus() {
 	g.Menus.Menus[string(MenuRemove)] = &Menu{
 		Name:        string(MenuRemove),
 		Type:        MenuRemove,
-		Title:       "Remove Roles",
-		Description: "Use the buttons below to remove Clearingway related roles!",
+		Title:       "Remove All Roles",
+		Description: "Are you sure you want to remove all Clearingway related roles? Ignore or dismiss this message to cancel.",
 	}
 }
 


### PR DESCRIPTION
In order to condense the number of buttons in our menus, we've opted to ditch all the remove role buttons except remove all, which has just been replaced with a confirmation button.